### PR TITLE
Rewrite frozen time for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Bunker is a key/value store library for efficiently storing large chunks of data
  Bunker provides support for encryption, compression and data signing
 See the [bunker readme](https://github.com/mailgun/holster/blob/master/bunker/README.md) for details
 
+## Clock
+A drop in (almost) replacement for the system `time` package to make scheduled
+events deterministic in tests. See the [clock readme](https://github.com/mailgun/holster/blob/master/clock/README.md) for details
+
 ## HttpSign
 HttpSign is a library for signing and authenticating HTTP requests between web services.
 See the [httpsign readme](https://github.com/mailgun/holster/blob/master/httpsign/README.md) for details
@@ -315,6 +319,9 @@ slice.ContainsString("two", haystack, nil) // false
 ```
 
 ## Clock
+
+DEPRECATED: Use [clock](https://github.com/mailgun/holster/blob/master/clock) package instead.
+
 Provides an interface which allows users to inject a modified clock during testing.
 
 ```go

--- a/clock/README.md
+++ b/clock/README.md
@@ -1,0 +1,55 @@
+# Clock
+
+A drop in (almost) replacement for the system `time` package. It provides a way
+to make scheduled calls, timers and tickers deterministic in tests. By default
+it forwards all calls to the system `time` package. In test, however, it is
+possible to enable the frozen clock mode, and advance time manually to make
+scheduled even trigger at certain moments.
+
+# Usage
+
+```go
+package foo
+
+import (
+    "time"
+
+    "github.com/mailgun/holster/clock"
+    . "gopkg.in/check.v1"
+)
+
+type FooSuite struct{}
+
+var _ = Suite(&FooSuite{})
+
+func (s *FooSuite) SetUpTest(c *C) {
+    // Freeze switches the clock package to the frozen clock mode. You need to
+    // advance time manually from now on. Note that all scheduled events, timers
+    // and ticker created before this call keep operating in real time.
+    //
+    // The initial time is set to 0 here, but you can set any datetime.
+    clock.Freeze(time.Time(0))
+}
+
+func (s *FooSuite) TearDownTest(c *C) {
+    // Reverts the effect of Freeze in test setup.
+    clock.Unfreeze()
+}
+
+func (s *FooSuite) TestSleep(c *C) {
+    var fired bool
+
+    clock.AfterFunc(100*time.Millisecond, func() {
+        fired = true
+    })
+ 
+    // Advance will make all fire all events, timers, tickers that are
+    // scheduled for the passed period of time. Note that scheduled functions
+    // are called from within Advanced unlike system time package that calls
+    // them in their own goroutine.
+    clock.Advance(99*time.Millisecond)
+    c.Assert(fired, Equals, false)
+    clock.Advance(1*time.Millisecond)
+    c.Assert(fired, Equals, true)
+}
+```

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -84,6 +84,13 @@ func Tick(d time.Duration) <-chan time.Time {
 	return provider.Tick(d)
 }
 
+// NewStoppedTimer returns a stopped timer. Call Reset to get it ticking.
+func NewStoppedTimer() Timer {
+	t := NewTimer(42 * time.Hour)
+	t.Stop()
+	return t
+}
+
 type clock interface {
 	Now() time.Time
 	Sleep(d time.Duration)

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,97 @@
+// Package clock provides the same functions as the system package time. In
+// production it forwards all calls to the system time package, but in tests
+// the time can be frozen by calling Freeze function and from that point it has
+// to be advanced manually with Advance function making all scheduled calls
+// deterministic.
+//
+// The functions provided by the package have the same parameters and return
+// values as their system counterparts with a few exceptions. Where either
+// *time.Timer or *time.Ticker is returned by a system function, the clock
+// package counterpart returns clock.Timer or clock.Ticker interface
+// respectively. The interfaces provide API as respective structs except C is
+// not a channel, but a function that returns <-chan time.Time.
+package clock
+
+import "time"
+
+// Freeze after this function is called all time related functions start
+// generate deterministic timers that are triggered by Advance function. It is
+// supposed to be used in tests only.
+func Freeze(now time.Time) {
+	provider = &frozenTime{now: now}
+}
+
+// Unfreeze reverses effect of Freeze.
+func Unfreeze() {
+	provider = &systemTime{}
+}
+
+// Makes the deterministic time move forward by the specified duration, firing
+// timers along the way in the natural order.
+func Advance(d time.Duration) {
+	ft, ok := provider.(*frozenTime)
+	if !ok {
+		panic("Freeze time first!")
+	}
+	ft.advance(d)
+}
+
+// Now see time.Now.
+func Now() time.Time {
+	return provider.Now()
+}
+
+// Sleep see time.Sleep.
+func Sleep(d time.Duration) {
+	provider.Sleep(d)
+}
+
+// After see time.After.
+func After(d time.Duration) <-chan time.Time {
+	return provider.After(d)
+}
+
+// Timer see time.Timer.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+// NewTimer see time.NewTimer.
+func NewTimer(d time.Duration) Timer {
+	return provider.NewTimer(d)
+}
+
+// AfterFunc see time.AfterFunc.
+func AfterFunc(d time.Duration, f func()) Timer {
+	return provider.AfterFunc(d, f)
+}
+
+// Ticker see time.Ticker.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// NewTicker see time.Ticker.
+func NewTicker(d time.Duration) Ticker {
+	return provider.NewTicker(d)
+}
+
+// Tick see time.Tick.
+func Tick(d time.Duration) <-chan time.Time {
+	return provider.Tick(d)
+}
+
+type clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+	After(d time.Duration) <-chan time.Time
+	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
+	NewTicker(d time.Duration) Ticker
+	Tick(d time.Duration) <-chan time.Time
+}
+
+var provider clock = &systemTime{}

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,0 +1,10 @@
+package clock
+
+import (
+	"testing"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}

--- a/clock/frozen.go
+++ b/clock/frozen.go
@@ -1,0 +1,195 @@
+package clock
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type frozenTime struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*frozenTimer
+}
+
+func (ft *frozenTime) Now() time.Time {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	return ft.now
+}
+
+func (ft *frozenTime) Sleep(d time.Duration) {
+	<-ft.NewTimer(d).C()
+}
+
+func (ft *frozenTime) After(d time.Duration) <-chan time.Time {
+	return ft.NewTimer(d).C()
+}
+
+func (ft *frozenTime) NewTimer(d time.Duration) Timer {
+	return ft.AfterFunc(d, nil)
+}
+
+func (ft *frozenTime) AfterFunc(d time.Duration, f func()) Timer {
+	t := &frozenTimer{
+		ft:   ft,
+		when: ft.Now().Add(d),
+		f:    f,
+	}
+	if f == nil {
+		t.c = make(chan time.Time, 1)
+	}
+	ft.startTimer(t)
+	return t
+}
+
+func (ft *frozenTime) advance(d time.Duration) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	ft.now = ft.now.Add(d)
+	for t := ft.nextExpired(); t != nil; t = ft.nextExpired() {
+		// Send the timer expiration time to the timer channel if it is
+		// defined. But make sure not to block on the send if the channel is
+		// full. This behavior will make a ticker skip beats if it readers are
+		// not fast enough.
+		if t.c != nil {
+			select {
+			case t.c <- t.when:
+			default:
+			}
+		}
+		// If it is a ticking timer then schedule next tick, otherwise mark it
+		// as stopped.
+		if t.interval != 0 {
+			t.when = t.when.Add(t.interval)
+			t.stopped = false
+			ft.unlockedStartTimer(t)
+		}
+		// If a function is associated with the timer then call it, but make
+		// sure to release the lock for the time of call it is necessary
+		// because the lock is not re-entrant but the function may need to
+		// start another timer or ticker.
+		if t.f != nil {
+			func() {
+				ft.mu.Unlock()
+				defer ft.mu.Lock()
+				t.f()
+			}()
+		}
+	}
+}
+
+func (ft *frozenTime) stopTimer(t *frozenTimer) bool {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	if t.stopped {
+		return false
+	}
+	for i, curr := range ft.timers {
+		if curr == t {
+			t.stopped = true
+			copy(ft.timers[i:], ft.timers[i+1:])
+			lastIdx := len(ft.timers) - 1
+			ft.timers[lastIdx] = nil
+			ft.timers = ft.timers[:lastIdx]
+			return true
+		}
+	}
+	return false
+}
+
+func (ft *frozenTime) nextExpired() *frozenTimer {
+	if len(ft.timers) == 0 {
+		return nil
+	}
+	t := ft.timers[0]
+	if ft.now.Before(t.when) {
+		return nil
+	}
+	copy(ft.timers, ft.timers[1:])
+	lastIdx := len(ft.timers) - 1
+	ft.timers[lastIdx] = nil
+	ft.timers = ft.timers[:lastIdx]
+	t.stopped = true
+	return t
+}
+
+func (ft *frozenTime) startTimer(t *frozenTimer) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	ft.unlockedStartTimer(t)
+}
+
+func (ft *frozenTime) unlockedStartTimer(t *frozenTimer) {
+	pos := 0
+	for _, curr := range ft.timers {
+		if t.when.Before(curr.when) {
+			break
+		}
+		pos++
+	}
+	ft.timers = append(ft.timers, nil)
+	copy(ft.timers[pos+1:], ft.timers[pos:])
+	ft.timers[pos] = t
+}
+
+type frozenTimer struct {
+	ft       *frozenTime
+	when     time.Time
+	interval time.Duration
+	stopped  bool
+	c        chan time.Time
+	f        func()
+}
+
+func (t *frozenTimer) C() <-chan time.Time {
+	return t.c
+}
+
+func (t *frozenTimer) Stop() bool {
+	return t.ft.stopTimer(t)
+}
+
+func (t *frozenTimer) Reset(d time.Duration) bool {
+	active := t.ft.stopTimer(t)
+	t.when = t.ft.Now().Add(d)
+	t.ft.startTimer(t)
+	return active
+}
+
+type frozenTicker struct {
+	t *frozenTimer
+}
+
+func (t *frozenTicker) C() <-chan time.Time {
+	return t.t.C()
+}
+
+func (t *frozenTicker) Stop() {
+	t.t.Stop()
+}
+
+func (ft *frozenTime) NewTicker(d time.Duration) Ticker {
+	if d <= 0 {
+		panic(errors.New("non-positive interval for NewTicker"))
+	}
+	t := &frozenTimer{
+		ft:       ft,
+		when:     ft.Now().Add(d),
+		interval: d,
+		c:        make(chan time.Time, 1),
+	}
+	ft.startTimer(t)
+	return &frozenTicker{t}
+}
+
+func (ft *frozenTime) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	return ft.NewTicker(d).C()
+}

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -1,0 +1,273 @@
+package clock
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type FrozenSuite struct {
+	epoch time.Time
+}
+
+var _ = Suite(&FrozenSuite{})
+
+func (s *FrozenSuite) SetUpSuite(c *C) {
+	var err error
+	s.epoch, err = time.Parse(time.RFC3339, "2009-02-19T00:00:00Z")
+	c.Assert(err, IsNil)
+}
+
+func (s *FrozenSuite) SetUpTest(c *C) {
+	Freeze(s.epoch)
+}
+
+func (s *FrozenSuite) TearDownTest(c *C) {
+	Unfreeze()
+}
+
+func (s *FrozenSuite) TestNow(c *C) {
+	c.Assert(Now(), Equals, s.epoch)
+	Advance(42*time.Millisecond)
+	c.Assert(Now(), Equals, s.epoch.Add(42*time.Millisecond))
+}
+
+func (s *FrozenSuite) TestSleep(c *C) {
+	hits := make(chan int, 100)
+
+	delays := []int{60, 100, 90, 131, 999, 5}
+	for i, tc := range []struct {
+		desc string
+		fn   func(delayMs int)
+	}{{
+		desc: "Sleep",
+		fn: func(delay int) {
+			Sleep(time.Duration(delay) * time.Millisecond)
+			hits <- delay
+		},
+	}, {
+		desc: "After",
+		fn: func(delay int) {
+			<-After(time.Duration(delay) * time.Millisecond)
+			hits <- delay
+		},
+	}, {
+		desc: "AfterFunc",
+		fn: func(delay int) {
+			AfterFunc(time.Duration(delay)*time.Millisecond,
+				func() {
+					hits <- delay
+				})
+		},
+	}, {
+		desc: "NewTimer",
+		fn: func(delay int) {
+			t := NewTimer(time.Duration(delay) * time.Millisecond)
+			<-t.C()
+			hits <- delay
+		},
+	}} {
+		fmt.Printf("Test case #%d: %s", i, tc.desc)
+		for _, delay := range delays {
+			go tc.fn(delay)
+		}
+		// Spin-wait for all goroutines to fall asleep.
+		ft := provider.(*frozenTime)
+		for {
+			if len(ft.timers) == len(delays) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		runningMs := 0
+		for i, delayMs := range []int{5, 60, 90, 100, 131, 999} {
+			fmt.Printf("Checking timer #%d, delay=%d\n", i, delayMs)
+			delta := delayMs - runningMs - 1
+			Advance(time.Duration(delta) * time.Millisecond)
+			// Check before each timer deadline that it is not triggered yet.
+			assertHits(c, hits, []int{})
+
+			// When
+			Advance(1 * time.Millisecond)
+
+			// Then
+			assertHits(c, hits, []int{delayMs})
+
+			runningMs += delta + 1
+		}
+
+		Advance(1000 * time.Millisecond)
+		assertHits(c, hits, []int{})
+	}
+}
+
+// Timers scheduled to trigger at the same time do that in the order they were
+// created.
+func (s *FrozenSuite) TestSameTime(c *C) {
+	var hits []int
+
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	AfterFunc(100, func() { hits = append(hits, 1) })
+	AfterFunc(99, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 5) })
+	AfterFunc(101, func() { hits = append(hits, 4) })
+	AfterFunc(101, func() { hits = append(hits, 6) })
+
+	// When
+	Advance(100)
+
+	// Then
+	c.Assert(hits, DeepEquals, []int{2, 3, 1, 5})
+}
+
+func (s *FrozenSuite) TestTimerStop(c *C) {
+	hits := []int{}
+
+	AfterFunc(100, func() { hits = append(hits, 1) })
+	t := AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	Advance(99)
+	c.Assert(hits, DeepEquals, []int{})
+
+	// When
+	active1 := t.Stop()
+	active2 := t.Stop()
+
+	// Then
+	c.Assert(active1, Equals, true)
+	c.Assert(active2, Equals, false)
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{1, 3})
+}
+
+func (s *FrozenSuite) TestReset(c *C) {
+	hits := []int{}
+
+	t1 := AfterFunc(100, func() { hits = append(hits, 1) })
+	t2 := AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	Advance(99)
+	c.Assert(hits, DeepEquals, []int{})
+
+	// When
+	active1 := t1.Reset(1) // Reset to the same time
+	active2 := t2.Reset(7)
+
+	// Then
+	c.Assert(active1, Equals, true)
+	c.Assert(active2, Equals, true)
+
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{3, 1})
+	Advance(5)
+	c.Assert(hits, DeepEquals, []int{3, 1})
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{3, 1, 2})
+}
+
+// Reset to the same time just puts the timer at the end of the trigger list
+// for the date.
+func (s *FrozenSuite) TestResetSame(c *C) {
+	hits := []int{}
+
+	t := AfterFunc(100, func() { hits = append(hits, 1) })
+	AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	AfterFunc(101, func() { hits = append(hits, 4) })
+	Advance(9)
+
+	// When
+	active := t.Reset(91)
+
+	// Then
+	c.Assert(active, Equals, true)
+
+	Advance(90)
+	c.Assert(hits, DeepEquals, []int{})
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{2, 3, 1})
+}
+
+func (s *FrozenSuite) TestTicker(c *C) {
+	t := NewTicker(100)
+
+	Advance(99)
+	assertNotFired(c, t.C())
+	Advance(1)
+	c.Assert(s.epoch.Add(100), Equals, <-t.C())
+	Advance(750)
+	c.Assert(s.epoch.Add(200), Equals, <-t.C())
+	Advance(49)
+	assertNotFired(c, t.C())
+	Advance(1)
+	c.Assert(s.epoch.Add(900), Equals, <-t.C())
+
+	t.Stop()
+	Advance(300)
+	assertNotFired(c, t.C())
+}
+
+func (s *FrozenSuite) TestTickerZero(c *C) {
+	defer func() {
+		recover()
+	}()
+
+	NewTicker(0)
+	c.Error("Should panic")
+}
+
+func (s *FrozenSuite) TestTick(c *C) {
+	ch := Tick(100)
+
+	Advance(99)
+	assertNotFired(c, ch)
+	Advance(1)
+	c.Assert(s.epoch.Add(100), Equals, <-ch)
+	Advance(750)
+	c.Assert(s.epoch.Add(200), Equals, <-ch)
+	Advance(49)
+	assertNotFired(c, ch)
+	Advance(1)
+	c.Assert(s.epoch.Add(900), Equals, <-ch)
+}
+
+func (s *FrozenSuite) TestTickZero(c *C) {
+	ch := Tick(0)
+	c.Assert(ch, IsNil)
+}
+
+func assertHits(c *C, got <-chan int, want []int) {
+	for i, w := range want {
+		var g int
+		select {
+		case g = <-got:
+		case <-time.After(100 * time.Millisecond):
+			c.Errorf("Missing hit: want=%v", w)
+			return
+		}
+		c.Assert(g, Equals, w, Commentf("Hit #%d", i))
+	}
+	for {
+		select {
+		case g := <-got:
+			c.Errorf("Unexpected hit: %v", g)
+		default:
+			return
+		}
+	}
+}
+
+func assertNotFired(c *C, ch <-chan time.Time) {
+	select {
+	case <-ch:
+		c.Error("Premature fire")
+	default:
+	}
+}

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -2,15 +2,10 @@ package clock
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) {
-	TestingT(t)
-}
 
 type FrozenSuite struct {
 	epoch time.Time
@@ -34,7 +29,7 @@ func (s *FrozenSuite) TearDownTest(c *C) {
 
 func (s *FrozenSuite) TestNow(c *C) {
 	c.Assert(Now(), Equals, s.epoch)
-	Advance(42*time.Millisecond)
+	Advance(42 * time.Millisecond)
 	c.Assert(Now(), Equals, s.epoch.Add(42*time.Millisecond))
 }
 
@@ -241,6 +236,18 @@ func (s *FrozenSuite) TestTick(c *C) {
 func (s *FrozenSuite) TestTickZero(c *C) {
 	ch := Tick(0)
 	c.Assert(ch, IsNil)
+}
+
+func (s *FrozenSuite) TestNewStoppedTimer(c *C) {
+	t := NewStoppedTimer()
+
+	// When/Then
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+	c.Assert(t.Stop(), Equals, false)
 }
 
 func assertHits(c *C, got <-chan int, want []int) {

--- a/clock/system.go
+++ b/clock/system.go
@@ -1,0 +1,64 @@
+package clock
+
+import "time"
+
+type systemTime struct {}
+
+func (st *systemTime) Now() time.Time {
+	return time.Now()
+}
+
+func (st *systemTime) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (st *systemTime) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+type systemTimer struct {
+	t *time.Timer
+}
+
+func (st *systemTime) NewTimer(d time.Duration) Timer {
+	t := time.NewTimer(d)
+	return &systemTimer{t}
+}
+
+func (st *systemTime) AfterFunc(d time.Duration, f func ()) Timer {
+	t := time.AfterFunc(d, f)
+	return &systemTimer{t}
+}
+
+func (t *systemTimer) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *systemTimer) Stop() bool {
+	return t.t.Stop()
+}
+
+func (t *systemTimer) Reset(d time.Duration) bool {
+	return t.t.Reset(d)
+}
+
+type systemTicker struct {
+	t *time.Ticker
+}
+
+func (t *systemTicker) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *systemTicker) Stop() {
+	t.t.Stop()
+}
+
+func (st *systemTime) NewTicker(d time.Duration) Ticker {
+	t := time.NewTicker(d)
+	return &systemTicker{t}
+}
+
+func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
+	return time.Tick(d)
+}

--- a/clock/system_test.go
+++ b/clock/system_test.go
@@ -1,0 +1,134 @@
+package clock
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type SystemSuite struct{}
+
+var _ = Suite(&SystemSuite{})
+
+func (s *SystemSuite) TestSleep(c *C) {
+	start := Now()
+
+	// When
+	Sleep(100 * time.Millisecond)
+
+	// Then
+	if Now().Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestAfter(c *C) {
+	start := Now()
+
+	// When
+	end := <-After(100 * time.Millisecond)
+
+	// Then
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestAfterFunc(c *C) {
+	start := Now()
+	endCh := make(chan time.Time, 1)
+
+	// When
+	AfterFunc(100*time.Millisecond, func() { endCh <- time.Now() })
+
+	// Then
+	end := <-endCh
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestNewTimer(c *C) {
+	start := Now()
+
+	// When
+	t := NewTimer(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestTimerStop(c *C) {
+	t := NewTimer(50 * time.Millisecond)
+
+	// When
+	active := t.Stop()
+
+	// Then
+	c.Assert(active, Equals, true)
+	time.Sleep(100)
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+}
+
+func (s *SystemSuite) TestTimerReset(c *C) {
+	start := time.Now()
+	t := NewTimer(300 * time.Millisecond)
+
+	// When
+	t.Reset(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) > 150*time.Millisecond {
+		c.Error("Waited too long")
+	}
+}
+
+func (s *SystemSuite) TestNewTicker(c *C) {
+	start := Now()
+
+	// When
+	t := NewTicker(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+	end = <-t.C()
+	if end.Sub(start) < 200*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+
+	t.Stop()
+	time.Sleep(150)
+	select {
+	case <-t.C():
+		c.Error("Ticker should not have fired")
+	default:
+	}
+}
+
+func (s *SystemSuite) TestTick(c *C) {
+	start := Now()
+
+	// When
+	ch := Tick(100 * time.Millisecond)
+
+	// Then
+	end := <-ch
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+	end = <-ch
+	if end.Sub(start) < 200*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}

--- a/clock/system_test.go
+++ b/clock/system_test.go
@@ -132,3 +132,15 @@ func (s *SystemSuite) TestTick(c *C) {
 		c.Error("Sleep did not last long enough")
 	}
 }
+
+func (s *SystemSuite) TestNewStoppedTimer(c *C) {
+	t := NewStoppedTimer()
+
+	// When/Then
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+	c.Assert(t.Stop(), Equals, false)
+}


### PR DESCRIPTION
Package `clock` provides the same functions as the system package `time`. In production it forwards all calls to the system `time` package, but in tests the time can be frozen by calling `Freeze` function and from that point it has to be advanced manually with `Advance` function making all scheduled calls deterministic.

The functions provided by the package have the same parameters and return values as their system counterparts with a few exceptions. Where either `*time.Timer` or `*time.Ticker` is returned by a system function, the `clock` package counterpart returns `clock.Timer` or `clock.Ticker` interface respectively. The interfaces provide API as respective `time` package structs, except `C` is not a channel, but a function that returns `<-chan time.Time`.

The `clock` package deprecates `holster.Clock` interface and all its implementations. Unlike `holster.Clock` it is less intrusive (in many cases it can be a drop-in replacement of the system time package). It is also more comprehensive, for it provides support for timers and tickers.

As a bonus it adds `clock.NewStoppedTimer` function. It returns a timer that never fires. You need to call `Reset` on the timer to get it ticking.