### PR TITLE
Return time since frozen from clock.Advance

### DIFF
--- a/bunker/backend.go
+++ b/bunker/backend.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pborman/uuid"
 	"github.com/mailgun/sandra"
+	"github.com/pborman/uuid"
 )
 
 // backend is an interface for bunker backends. It mainly exists in order to simplify testing

--- a/bunker/bunker.go
+++ b/bunker/bunker.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/mailgun/holster/secret"
+	"github.com/sirupsen/logrus"
 )
 
 type bunker struct {

--- a/clock/README.md
+++ b/clock/README.md
@@ -42,14 +42,15 @@ func (s *FooSuite) TestSleep(c *C) {
     clock.AfterFunc(100*time.Millisecond, func() {
         fired = true
     })
- 
+    clock.Advance(93*time.Millisecond)
+    
     // Advance will make all fire all events, timers, tickers that are
     // scheduled for the passed period of time. Note that scheduled functions
     // are called from within Advanced unlike system time package that calls
     // them in their own goroutine.
-    clock.Advance(99*time.Millisecond)
+    c.Assert(clock.Advance(6*time.Millisecond), Equals, 97*time.Millisecond)
     c.Assert(fired, Equals, false)
-    clock.Advance(1*time.Millisecond)
+    c.Assert(clock.Advance(1*time.Millisecond), Equals, 100*time.Millisecond)
     c.Assert(fired, Equals, true)
 }
 ```

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -2,6 +2,7 @@ package clock
 
 import (
 	"testing"
+
 	. "gopkg.in/check.v1"
 )
 

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -27,10 +27,13 @@ func (s *FrozenSuite) TearDownTest(c *C) {
 	Unfreeze()
 }
 
-func (s *FrozenSuite) TestNow(c *C) {
+func (s *FrozenSuite) TestAdvanceNow(c *C) {
 	c.Assert(Now(), Equals, s.epoch)
-	Advance(42 * time.Millisecond)
+	c.Assert(Advance(42 * time.Millisecond), Equals, 42*time.Millisecond)
 	c.Assert(Now(), Equals, s.epoch.Add(42*time.Millisecond))
+	c.Assert(Advance(13 * time.Millisecond), Equals, 55*time.Millisecond)
+	c.Assert(Advance(19 * time.Millisecond), Equals, 74*time.Millisecond)
+	c.Assert(Now(), Equals, s.epoch.Add(74*time.Millisecond))
 }
 
 func (s *FrozenSuite) TestSleep(c *C) {

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -29,10 +29,10 @@ func (s *FrozenSuite) TearDownTest(c *C) {
 
 func (s *FrozenSuite) TestAdvanceNow(c *C) {
 	c.Assert(Now(), Equals, s.epoch)
-	c.Assert(Advance(42 * time.Millisecond), Equals, 42*time.Millisecond)
+	c.Assert(Advance(42*time.Millisecond), Equals, 42*time.Millisecond)
 	c.Assert(Now(), Equals, s.epoch.Add(42*time.Millisecond))
-	c.Assert(Advance(13 * time.Millisecond), Equals, 55*time.Millisecond)
-	c.Assert(Advance(19 * time.Millisecond), Equals, 74*time.Millisecond)
+	c.Assert(Advance(13*time.Millisecond), Equals, 55*time.Millisecond)
+	c.Assert(Advance(19*time.Millisecond), Equals, 74*time.Millisecond)
 	c.Assert(Now(), Equals, s.epoch.Add(74*time.Millisecond))
 }
 

--- a/clock/system.go
+++ b/clock/system.go
@@ -2,7 +2,7 @@ package clock
 
 import "time"
 
-type systemTime struct {}
+type systemTime struct{}
 
 func (st *systemTime) Now() time.Time {
 	return time.Now()
@@ -25,7 +25,7 @@ func (st *systemTime) NewTimer(d time.Duration) Timer {
 	return &systemTimer{t}
 }
 
-func (st *systemTime) AfterFunc(d time.Duration, f func ()) Timer {
+func (st *systemTime) AfterFunc(d time.Duration, f func()) Timer {
 	t := time.AfterFunc(d, f)
 	return &systemTimer{t}
 }

--- a/clock_test.go
+++ b/clock_test.go
@@ -132,4 +132,3 @@ func Example_Clock_Usage() {
 
 	// Output: Time is Now: 2009-11-10 23:00:10 +0000 UTC
 }
-

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -95,9 +95,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/sirupsen/logrus"
 	"github.com/mailgun/holster/stack"
 	pkg "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // New returns an error with the supplied message.

--- a/errors/with_context_test.go
+++ b/errors/with_context_test.go
@@ -2,12 +2,10 @@ package errors_test
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
-	"io"
-
-	"github.com/ahmetalpbalkan/go-linq"
 	"github.com/mailgun/holster/errors"
 	"github.com/mailgun/holster/stack"
 	. "gopkg.in/check.v1"

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -21,7 +21,6 @@ import (
 	"net"
 
 	"github.com/mailgun/events"
-	"github.com/oschwald/geoip2-golang"
 )
 
 const (

--- a/misc.go
+++ b/misc.go
@@ -16,13 +16,12 @@ limitations under the License.
 package holster
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 
-	"fmt"
-
-	"github.com/sirupsen/logrus"
 	"github.com/fatih/structs"
-	"os"
+	"github.com/sirupsen/logrus"
 )
 
 // Given a struct or map[string]interface{} return as a logrus.Fields{} map
@@ -63,7 +62,6 @@ func ToFields(value interface{}) logrus.Fields {
 	}
 	return result
 }
-
 
 // Get the environment variable or return the default value if unset
 func GetEnv(envName, defaultValue string) string {

--- a/misc_test.go
+++ b/misc_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 package holster_test
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/mailgun/holster"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 

--- a/priority_queue_test.go
+++ b/priority_queue_test.go
@@ -16,9 +16,10 @@ limitations under the License.
 package holster_test
 
 import (
+	"fmt"
+
 	"github.com/mailgun/holster"
 	. "gopkg.in/check.v1"
-	"fmt"
 )
 
 type MinHeapSuite struct{}
@@ -91,22 +92,21 @@ func (s *MinHeapSuite) TestUpdate(c *C) {
 	c.Assert(toInt(mh.Peek().Value), Equals, 1)
 }
 
-
 func Example_Priority_Queue_Usage() {
 	queue := holster.NewPriorityQueue()
 
 	queue.Push(&holster.PQItem{
-		Value: "thing3",
+		Value:    "thing3",
 		Priority: 3,
 	})
 
 	queue.Push(&holster.PQItem{
-		Value: "thing1",
+		Value:    "thing1",
 		Priority: 1,
 	})
 
 	queue.Push(&holster.PQItem{
-		Value: "thing2",
+		Value:    "thing2",
 		Priority: 2,
 	})
 

--- a/ttlmap_test.go
+++ b/ttlmap_test.go
@@ -16,11 +16,11 @@ limitations under the License.
 package holster_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/mailgun/holster"
 	. "gopkg.in/check.v1"
-	"fmt"
 )
 
 type TestSuite struct {

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -1,12 +1,12 @@
 package useragent
 
 import (
-	"github.com/mailgun/events"
+	"fmt"
+	"strings"
 
 	"github.com/avct/uasurfer"
+	"github.com/mailgun/events"
 	"github.com/ua-parser/uap-go/uaparser"
-	"strings"
-	"fmt"
 )
 
 const (
@@ -21,13 +21,12 @@ const (
 	ClientMobileBrowser = "mobile browser"
 	ClientEmailClient   = "email client"
 	ClientRobot         = "robot"
-
 )
 
 var (
 	EmailClients = [...]string{"Windows Live Mail", "Outlook", "Apple Mail", "Thunderbird", "Lotus Notes", "Postbox", "Sparrow", "PocoMail"}
-	RegexesPath = "/var/mailgun/uap_regexes.yaml"
-	uasParser *uaparser.Parser
+	RegexesPath  = "/var/mailgun/uap_regexes.yaml"
+	uasParser    *uaparser.Parser
 )
 
 func Parse(uagent string) (events.ClientInfo, error) {
@@ -58,10 +57,10 @@ func Parse(uagent string) (events.ClientInfo, error) {
 	}
 
 	return events.ClientInfo{
-		UserAgent: uagent,
+		UserAgent:  uagent,
 		DeviceType: deviceType,
 		ClientName: clientName,
-		ClientOS: clientOs,
+		ClientOS:   clientOs,
 		ClientType: clientType,
 	}, nil
 }

--- a/waitgroup_test.go
+++ b/waitgroup_test.go
@@ -16,11 +16,9 @@ limitations under the License.
 package holster
 
 import (
+	"sync/atomic"
 	"time"
 
-	"sync/atomic"
-
-	"github.com/ahmetalpbalkan/go-linq"
 	"github.com/pkg/errors"
 	. "gopkg.in/check.v1"
 )


### PR DESCRIPTION
Made clock.Advance return how much time has passed since the time was frozen. It turned out to be very useful in tests to assert after each advance on the passed time. That makes it clear where we stand on the deterministic time scale, e.g.:

```go
c.Assert(clock.Advance(2), Equals, time.Duration(301)
```