### PR TITLE
Add type aliases to clock package

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -42,6 +42,13 @@ func Advance(d time.Duration) time.Duration {
 	return Now().UTC().Sub(frozenAt)
 }
 
+// Wait4Scheduled blocks until either there are n or more scheduled events, or
+// the timeout elapses. It returns true if the wait condition has been met
+// before the timeout expired, false otherwise.
+func Wait4Scheduled(count int, timeout time.Duration) bool {
+	return provider.Wait4Scheduled(count, timeout)
+}
+
 // Now see time.Now.
 func Now() time.Time {
 	return provider.Now()
@@ -105,6 +112,7 @@ type clock interface {
 	AfterFunc(d time.Duration, f func()) Timer
 	NewTicker(d time.Duration) Ticker
 	Tick(d time.Duration) <-chan time.Time
+	Wait4Scheduled(n int, timeout time.Duration) bool
 }
 
 var provider clock = &systemTime{}

--- a/clock/go19.go
+++ b/clock/go19.go
@@ -1,0 +1,105 @@
+// This file introduces aliases to allow using of the clock package as a
+// drop-in replacement of the standard time package.
+
+// +build go1.9
+package clock
+
+import "time"
+
+type (
+	Time     = time.Time
+	Duration = time.Duration
+	Location = time.Location
+
+	Weekday = time.Weekday
+	Month   = time.Month
+
+	ParseError = time.ParseError
+)
+
+const (
+	Nanosecond  = time.Nanosecond
+	Microsecond = time.Microsecond
+	Millisecond = time.Millisecond
+	Second      = time.Second
+	Minute      = time.Minute
+	Hour        = time.Hour
+
+	Sunday    = time.Sunday
+	Monday    = time.Monday
+	Tuesday   = time.Tuesday
+	Wednesday = time.Wednesday
+	Thursday  = time.Thursday
+	Friday    = time.Friday
+	Saturday  = time.Saturday
+
+	January   = time.January
+	February  = time.February
+	March     = time.March
+	April     = time.April
+	May       = time.May
+	June      = time.June
+	July      = time.July
+	August    = time.August
+	September = time.September
+	October   = time.October
+	November  = time.November
+	December  = time.December
+
+	ANSIC       = time.ANSIC
+	UnixDate    = time.UnixDate
+	RubyDate    = time.RubyDate
+	RFC822      = time.RFC822
+	RFC822Z     = time.RFC822Z
+	RFC850      = time.RFC850
+	RFC1123     = time.RFC1123
+	RFC1123Z    = time.RFC1123Z
+	RFC3339     = time.RFC3339
+	RFC3339Nano = time.RFC3339Nano
+	Kitchen     = time.Kitchen
+	Stamp       = time.Stamp
+	StampMilli  = time.StampMilli
+	StampMicro  = time.StampMicro
+	StampNano   = time.StampNano
+)
+
+var (
+	UTC   = time.UTC
+	Local = time.Local
+)
+
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time {
+	return time.Date(year, month, day, hour, min, sec, nsec, loc)
+}
+
+func FixedZone(name string, offset int) *Location {
+	return time.FixedZone(name, offset)
+}
+
+func LoadLocation(name string) (*Location, error) {
+	return time.LoadLocation(name)
+}
+
+func Parse(layout, value string) (Time, error) {
+	return time.Parse(layout, value)
+}
+
+func ParseDuration(s string) (Duration, error) {
+	return time.ParseDuration(s)
+}
+
+func ParseInLocation(layout, value string, loc *Location) (Time, error) {
+	return time.ParseInLocation(layout, value, loc)
+}
+
+func Since(t Time) Duration {
+	return time.Since(t)
+}
+
+func Unix(sec int64, nsec int64) Time {
+	return time.Unix(sec, nsec)
+}
+
+func Until(t Time) Duration {
+	return time.Until(t)
+}

--- a/clock/system.go
+++ b/clock/system.go
@@ -62,3 +62,7 @@ func (st *systemTime) NewTicker(d time.Duration) Ticker {
 func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
 	return time.Tick(d)
 }
+
+func (st *systemTime) Wait4Scheduled(count int, timeout time.Duration) bool {
+	panic("Not supported")
+}


### PR DESCRIPTION
* A set of aliases for types, constants, values and functions was added to make it possible to use the `clock` package as a drop-in replacement for the `time` package.
* Function `clock.Wait4Scheduled` was introduced to allow block test execution until the a specified number of timer events is scheduled or a timeout is expired. It is intended to be used in conjunction with `clock.Advance` to make sure that concurrently executing logic has scheduled timers/tickers to the deterministic clock before advancing time.