### PR TITLE
Until() can now manage multiple go routines

### DIFF
--- a/waitgroup.go
+++ b/waitgroup.go
@@ -46,7 +46,9 @@ func (wg *WaitGroup) Run(callBack func(interface{}) error, data interface{}) {
 // the `done` channel is closed. Implementations of the callBack function can listen
 // for the close to indicate a stop was requested.
 func (wg *WaitGroup) Until(callBack func(done chan struct{}) bool) {
-	wg.done = make(chan struct{})
+	if wg.done == nil {
+		wg.done = make(chan struct{})
+	}
 	wg.wg.Add(1)
 	go func() {
 		for {


### PR DESCRIPTION
 ## Purpose
Users can now manage multiple go routines with a single `WaitGroup` instance
```go
var wg holster.WaitGroup
wg.Until(func(done chan struct) bool { ... ])
wg.Until(func(done chan struct) bool { ... ])

time.Sleep(2)
wg.Stop() // Stops both go routines
```