### PR TITLE
fix lru deadlock issue

### DIFF
--- a/expire_cache.go
+++ b/expire_cache.go
@@ -177,8 +177,8 @@ func (c *ExpireCache) Each(concurrent int, callBack func(key interface{}, value 
 
 // Retrieve stats about the cache
 func (c *ExpireCache) GetStats() ExpireCacheStats {
-	c.stats.Size = c.Size()
 	c.mutex.Lock()
+	c.stats.Size = int64(len(c.cache))
 	defer func() {
 		c.stats = ExpireCacheStats{}
 		c.mutex.Unlock()


### PR DESCRIPTION
## Purpose
***NOTE: Includes a breaking change for LeaderElection***

* Fixes a LRUCache deadlock issue triggered when the cache is full and adding additional items to the cache.
* Made leader election etcd specific by renaming implementation to `EtcdElection`
* Etcd election now correctly records the hostname of the leader in etcd
