### PR TITLE
Election now handles connection interrupts gracefully

### DIFF
--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -19,7 +19,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	e, err := etcdutil.NewElection("cli-election", os.Args[1], nil)
+	client, err := etcdutil.NewClient(nil)
+	if err != nil {
+		fmt.Printf("while creating a new etcd client: %s\n", err)
+		os.Exit(1)
+	}
+
+	e, err := etcdutil.NewElection("cli-election", os.Args[1], client)
 	if err != nil {
 		fmt.Printf("while creating a new election: %s\n", err)
 		os.Exit(1)

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	e.Start()
+	err = e.Start()
 	if err != nil {
 		fmt.Printf("during election start: %s\n", err)
 		os.Exit(1)

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/mailgun/holster/etcdutil"
 	"github.com/sirupsen/logrus"
@@ -25,11 +25,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	e, err := etcdutil.NewElection("cli-election", os.Args[1], client)
+	/*resp, err := client.Get(context.Background(), "/elections/cli-election", clientv3.WithPrefix())
 	if err != nil {
-		fmt.Printf("while creating a new election: %s\n", err)
+		fmt.Printf("while creating a new etcd client: %s\n", err)
 		os.Exit(1)
-	}
+	}*/
+
+	e := etcdutil.NewElection(client, etcdutil.ElectionConfig{
+		Election:                "cli-election",
+		Candidate:               os.Args[1],
+		LeaderChannelSize:       10,
+		ResumeLeaderOnReconnect: true,
+		TTL: 10,
+	})
 
 	err = e.Start()
 	if err != nil {
@@ -53,8 +61,8 @@ func main() {
 		}
 	}()
 
-	for {
-		fmt.Printf("[%s] Leader: %t\n", os.Args[1], e.IsLeader())
-		time.Sleep(time.Second)
+	for leader := range e.LeaderChan() {
+		fmt.Printf("[%s] Leader: %t\n", os.Args[1], leader)
 	}
+
 }

--- a/etcdutil/election.go
+++ b/etcdutil/election.go
@@ -18,12 +18,25 @@ var log *logrus.Entry
 
 type LeaderElector interface {
 	IsLeader() bool
+	LeaderChan() chan bool
 	Concede() bool
 	Start() error
 	Stop()
 }
 
 type Election struct {
+	conf       ElectionConfig
+	session    *concurrency.Session
+	election   *concurrency.Election
+	client     *etcd.Client
+	cancel     context.CancelFunc
+	wg         holster.WaitGroup
+	ctx        context.Context
+	isLeader   int32
+	leaderChan chan bool
+}
+
+type ElectionConfig struct {
 	// The name of the election (IE: scout, blackbird, etc...)
 	Election string
 	// The name of this instance (IE: worker-n01, worker-n02, etc...)
@@ -32,76 +45,85 @@ type Election struct {
 	TTL int
 	// Report not leader when etcd connection is interrupted
 	LoseLeaderOnDisconnect bool
-
-	session  *concurrency.Session
-	election *concurrency.Election
-	client   *etcd.Client
-	cancel   context.CancelFunc
-	wg       holster.WaitGroup
-	ctx      context.Context
-	isLeader int32
+	// If we were leader before connection or service interruption attempt
+	// to resume leadership without initiating a new election
+	ResumeLeaderOnReconnect bool
+	// How long to wait until attempting to establish a new session between failures
+	ReconnectBackOff time.Duration
+	// The size of the leader channel buffer as returned by LeaderChan(). Set this to
+	// something other than zero to avoid losing leadership changes.
+	LeaderChannelSize int
 }
 
 // Use leader election if you have several instances of a service running in production
 // and you only want one of the service instances to preform a periodic task.
 //
-//	election, _ := etcdv3.NewElection("election-name", "", nil)
+//  client, _ := etcdutil.NewClient(nil)
+//
+//  election := etcdutil.NewElection(client, etcdutil.ElectionConfig{
+//      Election: "election-name",
+//      Candidate: "",
+//      TTL: 5,
+//  })
 //
 //  // Start the leader election and attempt to become leader
-//  election.Start()
+//  if err := election.Start(); err != nil {
+//      panic(err)
+//  }
 //
 //	// Returns true if we are leader (thread safe)
 //	if election.IsLeader() {
 //		// Do periodic thing
 //	}
 //
+//  select {
+//  case isLeader := <-election.LeaderChan():
+//  	fmt.Printf("Leader: %t\n", isLeader)
+//  }
+//
 // NOTE: If this instance is elected leader and connection is interrupted to etcd,
 // this library will continue to report it is leader until connection to etcd is resumed
 // and a new leader is elected. If you wish to lose leadership on disconnect set
 // `LoseLeaderOnDisconnect = true`
-func NewElection(election, candidate string, client *etcd.Client) (*Election, error) {
+func NewElection(client *etcd.Client, conf ElectionConfig) LeaderElector {
 	log = logrus.WithField("category", "election")
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	e := &Election{
-		Candidate: candidate,
-		Election:  election,
-		TTL:       5,
-		cancel:    cancelFunc,
-		ctx:       ctx,
-		client:    client,
+		conf:   conf,
+		client: client,
+		cancel: cancelFunc,
+		ctx:    ctx,
 	}
 
+	// Default to short 5 second leadership TTL
+	holster.SetDefault(&e.conf.TTL, 5)
+
+	e.leaderChan = make(chan bool, e.conf.LeaderChannelSize)
+	e.conf.Election = path.Join("/elections", e.conf.Election)
+
+	// Use the hostname if no candidate name provided
 	if host, err := os.Hostname(); err == nil {
-		holster.SetDefault(&e.Candidate, host)
+		holster.SetDefault(&e.conf.Candidate, host)
 	}
-
-	// Set a prefix key for elections
-	e.Election = path.Join("/elections", e.Election)
-
-	// Test the client
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	_, err := e.client.Get(ctx, e.Election)
-	if err != nil {
-		return nil, errors.Wrap(err, "while connecting to etcd")
-	}
-
-	return e, nil
+	return e
 }
 
 func (e *Election) newSession(id int64) error {
 	var err error
-	e.session, err = concurrency.NewSession(e.client, concurrency.WithTTL(e.TTL),
+	e.session, err = concurrency.NewSession(e.client, concurrency.WithTTL(e.conf.TTL),
 		concurrency.WithContext(e.ctx), concurrency.WithLease(etcd.LeaseID(id)))
 	if err != nil {
 		return errors.Wrap(err, "while creating new session")
 	}
-	e.election = concurrency.NewElection(e.session, e.Election)
+	e.election = concurrency.NewElection(e.session, e.conf.Election)
 	return nil
 }
 
 func (e *Election) Start() error {
+	if e.conf.Election == "" {
+		return errors.New("ElectionConfig.Election can not be empty")
+	}
+
 	err := e.newSession(0)
 	if err != nil {
 		return errors.Wrap(err, "while creating new initial etcd session")
@@ -121,100 +143,133 @@ func (e *Election) Start() error {
 			// If we are resuming an election from which we previously had leadership we
 			// have 2 options
 			// 1. Resume the leadership if the lease has not expired. This is a race as the
-			//    lease could expire in between the `Leader()` call and `Campaign()` calls.
-			//    If this happens `Campaign()` should return with an error as the resumed
-			//    session has expired.
+			//    lease could expire in between the `Leader()` call and when we resume
+			//    observing changes to the election. If this happens we should detect the
+			//    session has expired during the observation loop.
 			// 2. Resign the leadership immediately to allow a new leader to be chosen.
 			//    This option will almost always result in transfer of leadership.
-			//
-			// We choose option 1 here because transfer of leadership might be expensive
-			// for some users of this library and being a bit more chatty on reconnect can
-			// be worth the price of switching leadership needlessly.
 
 			// If we were the leader previously
-			if string(node.Kvs[0].Value) == e.Candidate {
-				// Recreate our session with the old lease
-				if err = e.newSession(node.Kvs[0].Lease); err != nil {
-					log.Errorf("while re-establishing session: %s", err)
-					// abandon resuming leadership
-					goto reconnect
+			if string(node.Kvs[0].Value) == e.conf.Candidate {
+				log.Debug("etcd reports we are still leader")
+				if e.conf.ResumeLeaderOnReconnect {
+					log.Debug("attempting to resume leadership")
+					// Recreate our session with the old lease id
+					if err = e.newSession(node.Kvs[0].Lease); err != nil {
+						log.Errorf("while re-establishing session with lease: %s", err)
+						// abandon resuming leadership
+						e.notifyLeaderChange(false)
+						goto reconnect
+					}
+					e.election = concurrency.ResumeElection(e.session, e.conf.Election,
+						string(node.Kvs[0].Key), node.Kvs[0].CreateRevision)
+
+					// Because Campaign() only returns if the election entry doesn't exist
+					// we must skip the campaign call and go directly to observe when resuming
+					goto observe
+				} else {
+					log.Debug("resigning leadership")
+					// If resign takes longer than our TTL then lease is expired and we are no longer leader anyway.
+					ctx, cancel := context.WithTimeout(e.ctx, time.Duration(e.conf.TTL)*time.Second)
+					election := concurrency.ResumeElection(e.session, e.conf.Election,
+						string(node.Kvs[0].Key), node.Kvs[0].CreateRevision)
+					err = election.Resign(ctx)
+					cancel()
+					e.notifyLeaderChange(false)
+					if err != nil {
+						log.Errorf("while resigning leadership after reconnect: %s", err)
+						goto reconnect
+					}
 				}
-				e.election = concurrency.ResumeElection(e.session, e.Election,
-					string(node.Kvs[0].Key), node.Kvs[0].CreateRevision)
 			}
-			// TODO: Sleep here to test race condition after resuming old session
 		}
 
 		// Reset leadership if we had it previously
-		atomic.StoreInt32(&e.isLeader, 0)
+		e.setLeader(false)
 
 		// Attempt to become leader
-		if err := e.election.Campaign(e.ctx, e.Candidate); err != nil {
+		if err := e.election.Campaign(e.ctx, e.conf.Candidate); err != nil {
 			if errors.Cause(err) == context.Canceled {
 				return false
 			}
-			log.Debug("campaign err: %s\n", err)
+			// Campaign does not return an error if session expires
+			log.Errorf("while campaigning for leader: %s", err)
 			e.session.Close()
 			goto reconnect
 		}
 
+	observe:
 		// If Campaign() returned without error, we are leader
-		atomic.StoreInt32(&e.isLeader, 1)
+		e.setLeader(true)
 
 		// Observe changes to leadership
 		observe = e.election.Observe(e.ctx)
 		for {
 			select {
-			case node, ok := <-observe:
+			case resp, ok := <-observe:
 				if !ok {
-					log.Debug("observe chan closed\n")
+					// Observe does not close if the session expires
 					e.session.Close()
 					goto reconnect
 				}
-				if string(node.Kvs[0].Value) == e.Candidate {
-					log.Debug("IS Leader")
-					atomic.StoreInt32(&e.isLeader, 1)
+				if string(resp.Kvs[0].Value) == e.conf.Candidate {
+					log.Debug("is Leader")
+					e.setLeader(true)
 				} else {
 					// We are not leader
-					log.Debug("NOT Leader")
-					atomic.StoreInt32(&e.isLeader, 0)
+					log.Debug("not Leader")
+					e.setLeader(false)
 					return true
 				}
 			case <-e.ctx.Done():
-				log.Debug("context cancelled")
 				return false
 			case <-e.session.Done():
-				log.Debug("session cancelled\n")
+				log.Debug("session cancelled while observing election")
 				goto reconnect
 			}
 		}
 
 	reconnect:
-		if e.LoseLeaderOnDisconnect {
-			atomic.StoreInt32(&e.isLeader, 0)
+		if e.conf.LoseLeaderOnDisconnect {
+			e.setLeader(false)
 		}
 
-		log.Debug("disconnected, creating new session")
-		if err = e.newSession(0); err != nil {
-			if errors.Cause(err) == context.Canceled {
-				return false
+		for {
+			log.Debug("disconnected, creating new session")
+			if err = e.newSession(0); err != nil {
+				if errors.Cause(err) == context.Canceled {
+					return false
+				}
+				log.Errorf("while creating new etcd session: %s", err)
+				tick := time.NewTicker(e.conf.ReconnectBackOff)
+				select {
+				case <-e.ctx.Done():
+					tick.Stop()
+					return false
+				case <-tick.C:
+					tick.Stop()
+				}
+				continue
 			}
-			log.Errorf("while creating new etcd session: %s", err)
-		} else {
-			log.Debug("New session created")
+			break
 		}
+		log.Debug("New session created")
 		return true
 	})
 
 	// Wait until we have a leader before returning
 	for {
-		_, err := e.election.Leader(e.ctx)
+		resp, err := e.election.Leader(e.ctx)
 		if err != nil {
 			if err != concurrency.ErrElectionNoLeader {
 				return err
 			}
 			time.Sleep(time.Millisecond * 300)
 			continue
+		}
+		// If we are not leader, notify the channel
+		if string(resp.Kvs[0].Value) != e.conf.Candidate {
+			e.notifyLeaderChange(false)
 		}
 		break
 	}
@@ -225,26 +280,61 @@ func (e *Election) Stop() {
 	e.Concede()
 	e.cancel()
 	e.wg.Wait()
+	close(e.leaderChan)
 }
 
 func (e *Election) IsLeader() bool {
 	return atomic.LoadInt32(&e.isLeader) == 1
 }
 
+func (e *Election) LeaderChan() chan bool {
+	return e.leaderChan
+}
+
 // Release leadership and return true if we own it, else do nothing and return false
 func (e *Election) Concede() bool {
 	if atomic.LoadInt32(&e.isLeader) == 1 {
 		// If resign takes longer than our TTL then lease is expired and we are no longer leader anyway.
-		ctx, cancel := context.WithTimeout(e.ctx, time.Duration(e.TTL)*time.Second)
+		ctx, cancel := context.WithTimeout(e.ctx, time.Duration(e.conf.TTL)*time.Second)
 		if err := e.election.Resign(ctx); err != nil {
 			log.WithField("err", err).
 				Error("while attempting to concede the election")
 		}
 		cancel()
-		atomic.StoreInt32(&e.isLeader, 0)
+		e.setLeader(false)
 		return true
 	}
 	return false
+}
+
+func (e *Election) setLeader(set bool) {
+	var requested int32
+	if set {
+		requested = 1
+	}
+
+	// Only notify if leadership changed
+	if requested == atomic.LoadInt32(&e.isLeader) {
+		return
+	}
+
+	atomic.StoreInt32(&e.isLeader, requested)
+	e.notifyLeaderChange(set)
+}
+
+func (e *Election) notifyLeaderChange(set bool) {
+	// If user expects to receive all leadership changes
+	if e.conf.LeaderChannelSize != 0 {
+		// Block until the leadership change is delivered
+		e.leaderChan <- set
+		return
+	}
+
+	// Else do not block if channel is not ready to received
+	select {
+	case e.leaderChan <- set:
+	default:
+	}
 }
 
 type LeaderElectionMock struct{}


### PR DESCRIPTION
## Purpose
1. Calls to `Campaign()` do not return an error if the session is cancelled or the lease the session is holding expires. It just returns as if it has gained leadership
2. The channel returned by `Observe()` does not get closed if the session is cancelled or the lease expires.
3. There is a bug in `ResumeElection()` which makes resuming elections impossible if you are already the leader. (See https://github.com/etcd-io/etcd/pull/10297)
## Implementation
* Re-create the session every time there is a session interrupt by listening to `session.Done()` 
* Attempt to resign leadership after connection interruption if etcd still considers us leader
* Added `election.LeaderChan()` which returns a channel users can listen on for leadership changes
* Changed signature of `etcdutil.NewElection()`

```go
e := etcdutil.NewElection(client, etcdutil.ElectionConfig{
	Election:               "cli-election",
	Candidate:               "worker-n01",
	LeaderChannelSize:       10,
	ResumeLeaderOnReconnect: true,
	TTL: 10,
})
if err = e.Start(); err != nil {
	fmt.Printf("during election start: %s\n", err)
	os.Exit(1)
}
for leader := range e.LeaderChan() {
	fmt.Printf("[%s] Leader: %t\n", os.Args[1], leader)
}
```