### PR TITLE
Fix clock.Since and clock.Until

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -22,10 +22,18 @@ var (
 
 // Freeze after this function is called all time related functions start
 // generate deterministic timers that are triggered by Advance function. It is
-// supposed to be used in tests only.
-func Freeze(now time.Time) {
+// supposed to be used in tests only. Returns an Unfreezer so it can be a
+// one-liner in tests: defer clock.Freeze(clock.Now()).Unfreeze()
+func Freeze(now time.Time) Unfreezer {
 	frozenAt = now.UTC()
 	provider = &frozenTime{now: now}
+	return Unfreezer{}
+}
+
+type Unfreezer struct{}
+
+func (u Unfreezer) Unfreeze() {
+	Unfreeze()
 }
 
 // Unfreeze reverses effect of Freeze.

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -284,6 +284,18 @@ func (s *FrozenSuite) TestWait4ScheduledImmediate(c *C) {
 	c.Assert(Wait4Scheduled(2, 0), Equals, true)
 }
 
+func (s *FrozenSuite) TestSince(c *C) {
+	c.Assert(Since(Now()), Equals, Duration(0))
+	c.Assert(Since(Now().Add(Millisecond)), Equals, -Millisecond)
+	c.Assert(Since(Now().Add(-Millisecond)), Equals, Millisecond)
+}
+
+func (s *FrozenSuite) TestUntil(c *C) {
+	c.Assert(Until(Now()), Equals, Duration(0))
+	c.Assert(Until(Now().Add(Millisecond)), Equals, Millisecond)
+	c.Assert(Until(Now().Add(-Millisecond)), Equals, -Millisecond)
+}
+
 func assertHits(c *C, got <-chan int, want []int) {
 	for i, w := range want {
 		var g int

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -2,10 +2,15 @@ package clock
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 )
+
+func TestFreezeUnfreeze(t *testing.T) {
+	defer Freeze(Now()).Unfreeze()
+}
 
 type FrozenSuite struct {
 	epoch time.Time

--- a/clock/go19.go
+++ b/clock/go19.go
@@ -93,14 +93,14 @@ func ParseInLocation(layout, value string, loc *Location) (Time, error) {
 	return time.ParseInLocation(layout, value, loc)
 }
 
-func Since(t Time) Duration {
-	return time.Since(t)
-}
-
 func Unix(sec int64, nsec int64) Time {
 	return time.Unix(sec, nsec)
 }
 
+func Since(t Time) Duration {
+	return provider.Now().Sub(t)
+}
+
 func Until(t Time) Duration {
-	return time.Until(t)
+	return t.Sub(provider.Now())
 }


### PR DESCRIPTION
Functions `clock.Since` and `clock.Until` were using realtime regardless whether `clock.Freeze` had been called or not.

Besides `clock.Freeze` function was made to return `clock.Unfreezer` to allow one line usage: `defer clock.Freeze(clock.Now()).Unfreeze()`