### PR TITLE
Election rewrite

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,55 @@
+package holster
+
+import (
+	"math"
+	"time"
+)
+
+var backoff = NewBackOff(time.Millisecond*300, time.Second*30, 2)
+
+type BackOffCounter struct {
+	min, max time.Duration
+	factor   float64
+	attempt  int
+}
+
+func NewBackOff(min, max time.Duration, factor float64) *BackOffCounter {
+	return &BackOffCounter{
+		factor: factor,
+		min:    min,
+		max:    max,
+	}
+}
+
+// Next returns the next back off duration based on the number of
+// times Next() was called. Each call to next returns the next factor
+// of back off. Call Reset() to reset the back off attempts to zero.
+func (b *BackOffCounter) Next() time.Duration {
+	d := b.BackOff(b.attempt)
+	b.attempt++
+	return d
+}
+
+// Reset sets the back off attempt counter to zero
+func (b *BackOffCounter) Reset() {
+	b.attempt = 0
+}
+
+// BackOff calculates the back depending on the attempts provided
+func (b *BackOffCounter) BackOff(attempt int) time.Duration {
+	d := time.Duration(float64(b.min) * math.Pow(b.factor, float64(attempt)))
+	if d > b.max {
+		return b.max
+	}
+	if d < b.min {
+		return b.min
+	}
+	return d
+}
+
+// BackOff is a convenience function which returns a back off duration
+// with a default 300 millisecond minimum and a 30 second maximum with
+// a factor of 2 for each attempt.
+func BackOff(attempt int) time.Duration {
+	return backoff.BackOff(attempt)
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,17 @@
+package holster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mailgun/holster"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffFunc(t *testing.T) {
+	d := holster.BackOff(0)
+	assert.Equal(t, time.Millisecond*300, d)
+
+	d = holster.BackOff(1)
+	assert.Equal(t, time.Millisecond*600, d)
+}

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -1,15 +1,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
-
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/mailgun/holster/etcdutil"
 	"github.com/sirupsen/logrus"
 )
+
+/*func checkErr(err error) {
+	if err != nil {
+		fmt.Printf("err: %s\n", err)
+		os.Exit(1)
+	}
+}*/
 
 func main() {
 	logrus.SetLevel(logrus.DebugLevel)
@@ -30,16 +39,18 @@ func main() {
 		fmt.Printf("while creating a new etcd client: %s\n", err)
 		os.Exit(1)
 	}*/
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
-	e := etcdutil.NewElection(client, etcdutil.ElectionConfig{
-		Election:                "cli-election",
-		Candidate:               os.Args[1],
-		LeaderChannelSize:       10,
-		ResumeLeaderOnReconnect: true,
-		TTL: 10,
+	leaderChan := make(chan etcdutil.Event, 5)
+	e, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
+		Election:  "cli-election",
+		Candidate: os.Args[1],
+		EventObserver: func(e etcdutil.Event) {
+			leaderChan <- e
+		},
+		TTL: 5,
 	})
-
-	err = e.Start()
 	if err != nil {
 		fmt.Printf("during election start: %s\n", err)
 		os.Exit(1)
@@ -54,15 +65,14 @@ func main() {
 				switch sig {
 				case syscall.SIGINT:
 					fmt.Printf("[%s] Concede and exit\n", os.Args[1])
-					e.Stop()
+					e.Close()
 					os.Exit(1)
 				}
 			}
 		}
 	}()
 
-	for leader := range e.LeaderChan() {
-		fmt.Printf("[%s] Leader: %t\n", os.Args[1], leader)
+	for e := range leaderChan {
+		spew.Printf("[%s] %v\n", os.Args[1], e)
 	}
-
 }

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -34,11 +34,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	/*resp, err := client.Get(context.Background(), "/elections/cli-election", clientv3.WithPrefix())
-	if err != nil {
-		fmt.Printf("while creating a new etcd client: %s\n", err)
-		os.Exit(1)
-	}*/
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 

--- a/etcdutil/docker-compose.yaml
+++ b/etcdutil/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
         -enable-v2=false
     ports:
         - "22379:22379"
-  proxy:
-    image: shopify/toxiproxy:latest
-    ports:
-      - "2379:2379"
-      - "8474:8474"
+#  proxy:
+#    image: shopify/toxiproxy:latest
+#    ports:
+#      - "2379:2379"
+#      - "8474:8474"

--- a/etcdutil/docker-compose.yaml
+++ b/etcdutil/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
         -enable-v2=false
     ports:
         - "22379:22379"
-#  proxy:
-#    image: shopify/toxiproxy:latest
-#    ports:
-#      - "2379:2379"
-#      - "8474:8474"
+  proxy:
+    image: shopify/toxiproxy:latest
+    ports:
+      - "2379:2379"
+      - "8474:8474"

--- a/etcdutil/docker-compose.yaml
+++ b/etcdutil/docker-compose.yaml
@@ -1,0 +1,28 @@
+# This setup is for testing only, all communication with 
+# etcd is done through the proxy. You have to create a proxy
+# with toxiproxy-cli before you can connect to etcd
+#
+# toxiproxy-cli create etcd --listen 0.0.0.0:2379 --upstream etcd:22379
+
+version: '3.2'
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.2
+    command: >
+        /usr/local/bin/etcd
+        -name etcd0
+        -advertise-client-urls http://localhost:2379
+        -listen-client-urls http://0.0.0.0:22379
+        -initial-advertise-peer-urls http://0.0.0.0:2381
+        -listen-peer-urls http://0.0.0.0:2381
+        -initial-cluster-token etcd-cluster-1
+        -initial-cluster etcd0=http://0.0.0.0:2381
+        -initial-cluster-state new
+        -enable-v2=false
+    ports:
+        - "22379:22379"
+#  proxy:
+#    image: shopify/toxiproxy:latest
+#    ports:
+#      - "2379:2379"
+#      - "8474:8474"

--- a/etcdutil/election.go
+++ b/etcdutil/election.go
@@ -16,12 +16,12 @@ import (
 )
 
 type LeaderElector interface {
-	Start(context.Context) error
-	LeaderChan() chan bool
 	IsLeader() bool
-	Concede() bool
-	Stop()
+	Concede() (bool, error)
+	Close()
 }
+
+var _ LeaderElector = &Election{}
 
 type Event struct {
 	// True if our candidate is leader

--- a/etcdutil/election.go
+++ b/etcdutil/election.go
@@ -24,10 +24,18 @@ type LeaderElector interface {
 }
 
 type Event struct {
-	IsLeader   bool
-	LeaderKey  string
+	// True if our candidate is leader
+	IsLeader bool
+	// True if the election is shutdown and
+	// no further events will follow.
+	IsDone bool
+	// Holds the current leader key
+	LeaderKey string
+	// Hold the current leaders data
 	LeaderData string
-	Err        error
+	// If not nil, contains an error encountered
+	// while participating in the election.
+	Err error
 }
 
 type EventObserver func(Event)
@@ -360,6 +368,8 @@ func (e *Election) onLeaderChange(kv *mvccpb.KeyValue) {
 		}
 		event.LeaderKey = string(kv.Key)
 		event.LeaderData = string(kv.Value)
+	} else {
+		event.IsDone = true
 	}
 
 	for _, v := range e.observers {

--- a/etcdutil/election_test.go
+++ b/etcdutil/election_test.go
@@ -1,0 +1,40 @@
+package etcdutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mailgun/holster/etcdutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestElection(t *testing.T) {
+	client, err := etcdutil.NewClient(nil)
+	require.Nil(t, err)
+
+	election := etcdutil.NewElection(client, etcdutil.ElectionConfig{
+		Log:       logrus.WithField("category", "election"),
+		Election:  "/my-election",
+		Candidate: "me",
+	})
+
+	election.Register(func(e etcdutil.ElectionEvent) {
+		switch e.Event {
+		case etcdutil.EventGainLeader:
+			// I'm leader!
+		case etcdutil.EventLostLeader:
+			// I'm NOT leader!
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	err = election.Start(ctx)
+	require.Nil(t, err)
+
+	assert.Equal(t, true, election.IsLeader())
+}

--- a/etcdutil/election_test.go
+++ b/etcdutil/election_test.go
@@ -2,7 +2,6 @@ package etcdutil_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -52,7 +51,6 @@ func TestTwoCampaigns(t *testing.T) {
 	c2Chan := make(chan bool, 5)
 	c2, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
 		EventObserver: func(e etcdutil.Event) {
-			fmt.Printf("Observed: %t err: %v\n", e.IsLeader, err)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -71,9 +69,9 @@ func TestTwoCampaigns(t *testing.T) {
 	assert.Equal(t, false, c1.IsLeader())
 
 	// Second campaign should become leader
-	/*assert.Equal(t, false, <-c2Chan)
+	assert.Equal(t, false, <-c2Chan)
 	assert.Equal(t, true, <-c2Chan)
 
 	c2.Close()
-	assert.Equal(t, false, <-c2Chan)*/
+	assert.Equal(t, false, <-c2Chan)
 }

--- a/etcdutil/session.go
+++ b/etcdutil/session.go
@@ -2,6 +2,8 @@ package etcdutil
 
 import (
 	"context"
+	"io/ioutil"
+	"sync"
 	"time"
 
 	etcd "github.com/coreos/etcd/clientv3"
@@ -9,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+const NoLease = etcd.LeaseID(-1)
 
 type SessionObserver func(id etcd.LeaseID)
 
@@ -21,28 +25,47 @@ type Session struct {
 	cancel        context.CancelFunc
 	conf          SessionConfig
 	client        *etcd.Client
+	timeout       time.Duration
+	once          sync.Once
 }
 
 type SessionConfig struct {
 	Log      *logrus.Entry
-	Timeout  time.Duration
+	TTL      int64
 	Observer SessionObserver
 }
 
+// NulObserver is used if no session observer is provided in the SessionConfig
+func NullObserver(s SessionObserver) {}
+
+// NewSession creates a lease and monitors lease keep alive's for connectivity.
+// Once a lease ID is granted SessionConfig.Observer is called with the granted lease.
+// If connectivity is lost with etcd SessionConfig.Observer is called again with -1 (NoLease)
+// as the lease ID. The Session will continue to try to gain another lease, once a new lease
+// is gained SessionConfig.Observer is called again with the new lease id.
 func NewSession(ctx context.Context, c *etcd.Client, conf SessionConfig) (*Session, error) {
-	// TODO: Check for Log
-	// TODO: Set default timeout
-	// TODO: Provide a dummy observer
-	// TODO: Require etcd client
-	s := Session{
-		client: c,
-		conf:   conf,
+	null := logrus.New()
+	null.SetOutput(ioutil.Discard)
+
+	holster.SetDefault(&conf.Log, null.WithField("category", "null"))
+	holster.SetDefault(&conf.TTL, int64(30))
+	holster.SetDefault(&conf.Observer, NullObserver)
+
+	conf.Log.Debug("New Session")
+
+	if c == nil {
+		return nil, errors.New("provided etcd client cannot be nil")
 	}
+
+	s := Session{
+		timeout: time.Second * time.Duration(conf.TTL),
+		conf:    conf,
+		client:  c,
+	}
+
 	return &s, s.start(ctx)
 }
 
-// TODO: How do we shutdown (Add Stop())
-// TODO: What does public interface look like. (Write a test)
 func (s *Session) start(ctx context.Context) (err error) {
 
 	if err = s.gainLease(ctx); err != nil {
@@ -50,14 +73,17 @@ func (s *Session) start(ctx context.Context) (err error) {
 	}
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
+	ticker := time.NewTicker(s.timeout)
+	s.lastKeepAlive = time.Now()
 
 	s.wg.Until(func(done chan struct{}) bool {
+		s.conf.Log.Debug("running")
 		// If we have lost our keep alive, attempt to regain it
 		if s.keepAlive == nil {
 			if err = s.gainLease(s.ctx); err != nil {
-				s.conf.Log.WithError(err).Error("while attempting to gain lease")
+				s.conf.Log.WithError(err).Error("while attempting to gain new lease")
 				select {
-				case <-time.After(s.conf.Timeout):
+				case <-time.After(s.timeout):
 					return true
 				case <-s.ctx.Done():
 					return false
@@ -68,20 +94,24 @@ func (s *Session) start(ctx context.Context) (err error) {
 		select {
 		case _, ok := <-s.keepAlive:
 			if !ok {
-				s.conf.Log.Warn("keep alive lost")
+				s.conf.Log.Warn("heartbeat lost")
 				s.keepAlive = nil
 			}
-
-			// Ensure we are getting keep alive's regularly
-			if s.lastKeepAlive.Sub(time.Now()) > s.conf.Timeout {
-				s.conf.Log.Warn("too long between keep alive heartbeats")
-				s.keepAlive = nil
-			}
+			s.conf.Log.Debug("heartbeat received")
 			s.lastKeepAlive = time.Now()
+
+		case <-ticker.C:
+			s.conf.Log.Debugf("ticker '%v'", time.Now().Sub(s.lastKeepAlive))
+			// Ensure we are getting heartbeats regularly
+			if time.Now().Sub(s.lastKeepAlive) > s.timeout {
+				s.conf.Log.Warn("too long between heartbeats")
+				s.keepAlive = nil
+			}
 		case <-done:
+			s.conf.Log.Debug("ticker")
 			if s.lease != nil {
-				ctx, cancel := context.WithTimeout(context.Background(), s.conf.Timeout)
-				if _, err := s.conf.Client.Revoke(ctx, s.lease.ID); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+				if _, err := s.client.Revoke(ctx, s.lease.ID); err != nil {
 					s.conf.Log.WithError(err).Error("while revoking our lease during shutdown")
 				}
 				cancel()
@@ -90,30 +120,38 @@ func (s *Session) start(ctx context.Context) (err error) {
 		}
 
 		if s.keepAlive == nil {
-			s.conf.Observer(ElectionEvent{
-				Event: EventLostLease,
-			})
+			s.conf.Observer(NoLease)
 		}
 		return true
 	})
+
 	return err
 }
 
-func (e *Session) gainLease(ctx context.Context) error {
-	e.emitLog(nil, "attempting to grant new lease")
-	lease, err := e.client.Grant(ctx, e.conf.TTL)
+// Close terminates the session shutting down all network operations,
+// then SessionConfig.Observer is called with -1 (NoLease)
+func (s *Session) Close() {
+	s.once.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
+		s.wg.Stop()
+		s.conf.Observer(NoLease)
+	})
+}
+
+func (s *Session) gainLease(ctx context.Context) error {
+	s.conf.Log.Debug("attempting to grant new lease")
+	lease, err := s.client.Grant(ctx, s.conf.TTL)
 	if err != nil {
 		return errors.Wrapf(err, "during grant lease")
 	}
 
-	keepAlive, err := e.client.KeepAlive(e.ctx, lease.ID)
+	s.keepAlive, err = s.client.KeepAlive(ctx, lease.ID)
 	if err != nil {
 		return err
 	}
-	s.keepAlive = keepAlive
-	e.emit(ElectionEvent{
-		Event:   EventGainLease,
-		LeaseID: lease.ID,
-	})
+	s.conf.Log.Debugf("new lease %d", lease.ID)
+	s.conf.Observer(lease.ID)
 	return nil
 }

--- a/etcdutil/session.go
+++ b/etcdutil/session.go
@@ -1,0 +1,119 @@
+package etcdutil
+
+import (
+	"context"
+	"time"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type SessionObserver func(id etcd.LeaseID)
+
+type Session struct {
+	keepAlive     <-chan *etcd.LeaseKeepAliveResponse
+	lease         *etcd.LeaseGrantResponse
+	lastKeepAlive time.Time
+	wg            holster.WaitGroup
+	ctx           context.Context
+	cancel        context.CancelFunc
+	conf          SessionConfig
+	client        *etcd.Client
+}
+
+type SessionConfig struct {
+	Log      *logrus.Entry
+	Timeout  time.Duration
+	Observer SessionObserver
+}
+
+func NewSession(ctx context.Context, c *etcd.Client, conf SessionConfig) (*Session, error) {
+	// TODO: Check for Log
+	// TODO: Set default timeout
+	// TODO: Provide a dummy observer
+	// TODO: Require etcd client
+	s := Session{
+		client: c,
+		conf:   conf,
+	}
+	return &s, s.start(ctx)
+}
+
+// TODO: How do we shutdown (Add Stop())
+// TODO: What does public interface look like. (Write a test)
+func (s *Session) start(ctx context.Context) (err error) {
+
+	if err = s.gainLease(ctx); err != nil {
+		return errors.Wrap(err, "during initial lease grant")
+	}
+
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	s.wg.Until(func(done chan struct{}) bool {
+		// If we have lost our keep alive, attempt to regain it
+		if s.keepAlive == nil {
+			if err = s.gainLease(s.ctx); err != nil {
+				s.conf.Log.WithError(err).Error("while attempting to gain lease")
+				select {
+				case <-time.After(s.conf.Timeout):
+					return true
+				case <-s.ctx.Done():
+					return false
+				}
+			}
+		}
+
+		select {
+		case _, ok := <-s.keepAlive:
+			if !ok {
+				s.conf.Log.Warn("keep alive lost")
+				s.keepAlive = nil
+			}
+
+			// Ensure we are getting keep alive's regularly
+			if s.lastKeepAlive.Sub(time.Now()) > s.conf.Timeout {
+				s.conf.Log.Warn("too long between keep alive heartbeats")
+				s.keepAlive = nil
+			}
+			s.lastKeepAlive = time.Now()
+		case <-done:
+			if s.lease != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), s.conf.Timeout)
+				if _, err := s.conf.Client.Revoke(ctx, s.lease.ID); err != nil {
+					s.conf.Log.WithError(err).Error("while revoking our lease during shutdown")
+				}
+				cancel()
+			}
+			return false
+		}
+
+		if s.keepAlive == nil {
+			s.conf.Observer(ElectionEvent{
+				Event: EventLostLease,
+			})
+		}
+		return true
+	})
+	return err
+}
+
+func (e *Session) gainLease(ctx context.Context) error {
+	e.emitLog(nil, "attempting to grant new lease")
+	lease, err := e.client.Grant(ctx, e.conf.TTL)
+	if err != nil {
+		return errors.Wrapf(err, "during grant lease")
+	}
+
+	keepAlive, err := e.client.KeepAlive(e.ctx, lease.ID)
+	if err != nil {
+		return err
+	}
+	s.keepAlive = keepAlive
+	e.emit(ElectionEvent{
+		Event:   EventGainLease,
+		LeaseID: lease.ID,
+	})
+	return nil
+}

--- a/etcdutil/session_test.go
+++ b/etcdutil/session_test.go
@@ -87,7 +87,6 @@ func TestConnectivityLost(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 
 	session, err := etcdutil.NewSession(client, etcdutil.SessionConfig{
-		Log: logrus.WithField("category", "test"),
 		Observer: func(leaseId etcd.LeaseID, err error) {
 			if err != nil {
 				t.Fatal(err)

--- a/etcdutil/session_test.go
+++ b/etcdutil/session_test.go
@@ -1,0 +1,121 @@
+package etcdutil_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Shopify/toxiproxy"
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster/etcdutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var proxy *toxiproxy.Proxy
+var client *etcd.Client
+
+func TestMain(m *testing.M) {
+	proxy = toxiproxy.NewProxy()
+	proxy.Name = "etcd"
+	proxy.Upstream = "localhost:22379"
+	proxy.Listen = "0.0.0.0:2379"
+
+	if err := proxy.Start(); err != nil {
+		fmt.Printf("failed to start toxiproxy\n")
+		os.Exit(1)
+	}
+
+	var err error
+	client, err = etcdutil.NewClient(nil)
+	if err != nil {
+		fmt.Printf("failed to connect to etcd\n")
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	proxy.Stop()
+	client.Close()
+	os.Exit(code)
+}
+
+func TestNewSession(t *testing.T) {
+	leaseChan := make(chan etcd.LeaseID, 1)
+	getLease := func() etcd.LeaseID {
+		select {
+		case id := <-leaseChan:
+			return id
+		case <-time.After(time.Second * 5):
+			require.FailNow(t, "Timeout waiting for lease id")
+		}
+		return 0
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, err := etcdutil.NewSession(ctx, client, etcdutil.SessionConfig{
+		Observer: func(leaseId etcd.LeaseID) {
+			leaseChan <- leaseId
+		},
+	})
+	require.Nil(t, err)
+	defer session.Close()
+
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	session.Close()
+
+	assert.Equal(t, etcdutil.NoLease, getLease())
+}
+
+func TestConnectivityLost(t *testing.T) {
+	leaseChan := make(chan etcd.LeaseID, 1)
+
+	getLease := func() etcd.LeaseID {
+		select {
+		case id := <-leaseChan:
+			return id
+		case <-time.After(time.Second * 5):
+			require.FailNow(t, "Timeout waiting for lease id")
+		}
+		return 0
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//logrus.SetLevel(logrus.DebugLevel)
+
+	session, err := etcdutil.NewSession(ctx, client, etcdutil.SessionConfig{
+		//Log: logrus.WithField("category", "test"),
+		Observer: func(leaseId etcd.LeaseID) {
+			leaseChan <- leaseId
+		},
+		TTL: 1,
+	})
+	require.Nil(t, err)
+	defer session.Close()
+
+	// Assert we get a valid lease id
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	// Interrupt the connection
+	proxy.Stop()
+
+	// Wait for session to realize the connection is gone
+	assert.Equal(t, etcdutil.NoLease, getLease())
+
+	// Restore the connection
+	require.Nil(t, proxy.Start())
+
+	// We should get a new lease
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	session.Close()
+
+	// Should get a final NoLease after close
+	assert.Equal(t, etcdutil.NoLease, getLease())
+}


### PR DESCRIPTION
This PR Changes the usage for etcdutil.NewElection() and how it handles the election. Session disconnects and keep alive interrupts are handled gracefully.  Unlike the concurrency.Election library....