### PR TITLE
PIP-598: Adopt go mod semantic import path

### DIFF
--- a/v3/clock/README.md
+++ b/v3/clock/README.md
@@ -1,0 +1,56 @@
+# Clock
+
+A drop in (almost) replacement for the system `time` package. It provides a way
+to make scheduled calls, timers and tickers deterministic in tests. By default
+it forwards all calls to the system `time` package. In test, however, it is
+possible to enable the frozen clock mode, and advance time manually to make
+scheduled even trigger at certain moments.
+
+# Usage
+
+```go
+package foo
+
+import (
+    "time"
+
+    "github.com/mailgun/holster/clock"
+    . "gopkg.in/check.v1"
+)
+
+type FooSuite struct{}
+
+var _ = Suite(&FooSuite{})
+
+func (s *FooSuite) SetUpTest(c *C) {
+    // Freeze switches the clock package to the frozen clock mode. You need to
+    // advance time manually from now on. Note that all scheduled events, timers
+    // and ticker created before this call keep operating in real time.
+    //
+    // The initial time is set to 0 here, but you can set any datetime.
+    clock.Freeze(time.Time(0))
+}
+
+func (s *FooSuite) TearDownTest(c *C) {
+    // Reverts the effect of Freeze in test setup.
+    clock.Unfreeze()
+}
+
+func (s *FooSuite) TestSleep(c *C) {
+    var fired bool
+
+    clock.AfterFunc(100*time.Millisecond, func() {
+        fired = true
+    })
+    clock.Advance(93*time.Millisecond)
+    
+    // Advance will make all fire all events, timers, tickers that are
+    // scheduled for the passed period of time. Note that scheduled functions
+    // are called from within Advanced unlike system time package that calls
+    // them in their own goroutine.
+    c.Assert(clock.Advance(6*time.Millisecond), Equals, 97*time.Millisecond)
+    c.Assert(fired, Equals, false)
+    c.Assert(clock.Advance(1*time.Millisecond), Equals, 100*time.Millisecond)
+    c.Assert(fired, Equals, true)
+}
+```

--- a/v3/clock/clock.go
+++ b/v3/clock/clock.go
@@ -1,0 +1,135 @@
+// Package clock provides the same functions as the system package time. In
+// production it forwards all calls to the system time package, but in tests
+// the time can be frozen by calling Freeze function and from that point it has
+// to be advanced manually with Advance function making all scheduled calls
+// deterministic.
+//
+// The functions provided by the package have the same parameters and return
+// values as their system counterparts with a few exceptions. Where either
+// *time.Timer or *time.Ticker is returned by a system function, the clock
+// package counterpart returns clock.Timer or clock.Ticker interface
+// respectively. The interfaces provide API as respective structs except C is
+// not a channel, but a function that returns <-chan time.Time.
+package clock
+
+import "time"
+
+var (
+	frozenAt time.Time
+	realtime       = &systemTime{}
+	provider Clock = realtime
+)
+
+// Freeze after this function is called all time related functions start
+// generate deterministic timers that are triggered by Advance function. It is
+// supposed to be used in tests only. Returns an Unfreezer so it can be a
+// one-liner in tests: defer clock.Freeze(clock.Now()).Unfreeze()
+func Freeze(now time.Time) Unfreezer {
+	frozenAt = now.UTC()
+	provider = &frozenTime{now: now}
+	return Unfreezer{}
+}
+
+type Unfreezer struct{}
+
+func (u Unfreezer) Unfreeze() {
+	Unfreeze()
+}
+
+// Unfreeze reverses effect of Freeze.
+func Unfreeze() {
+	provider = realtime
+}
+
+// Realtime returns a clock provider wrapping the SDK's time package. It is
+// supposed to be used in tests when time is frozen to schedule test timeouts.
+func Realtime() Clock {
+	return realtime
+}
+
+// Makes the deterministic time move forward by the specified duration, firing
+// timers along the way in the natural order. It returns how much time has
+// passed since it was frozen. So you can assert on the return value in tests
+// to make it explicit where you stand on the deterministic time scale.
+func Advance(d time.Duration) time.Duration {
+	ft, ok := provider.(*frozenTime)
+	if !ok {
+		panic("Freeze time first!")
+	}
+	ft.advance(d)
+	return Now().UTC().Sub(frozenAt)
+}
+
+// Wait4Scheduled blocks until either there are n or more scheduled events, or
+// the timeout elapses. It returns true if the wait condition has been met
+// before the timeout expired, false otherwise.
+func Wait4Scheduled(count int, timeout time.Duration) bool {
+	return provider.Wait4Scheduled(count, timeout)
+}
+
+// Now see time.Now.
+func Now() time.Time {
+	return provider.Now()
+}
+
+// Sleep see time.Sleep.
+func Sleep(d time.Duration) {
+	provider.Sleep(d)
+}
+
+// After see time.After.
+func After(d time.Duration) <-chan time.Time {
+	return provider.After(d)
+}
+
+// Timer see time.Timer.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+// NewTimer see time.NewTimer.
+func NewTimer(d time.Duration) Timer {
+	return provider.NewTimer(d)
+}
+
+// AfterFunc see time.AfterFunc.
+func AfterFunc(d time.Duration, f func()) Timer {
+	return provider.AfterFunc(d, f)
+}
+
+// Ticker see time.Ticker.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// NewTicker see time.Ticker.
+func NewTicker(d time.Duration) Ticker {
+	return provider.NewTicker(d)
+}
+
+// Tick see time.Tick.
+func Tick(d time.Duration) <-chan time.Time {
+	return provider.Tick(d)
+}
+
+// NewStoppedTimer returns a stopped timer. Call Reset to get it ticking.
+func NewStoppedTimer() Timer {
+	t := NewTimer(42 * time.Hour)
+	t.Stop()
+	return t
+}
+
+// Clock is an interface that mimics the one of the SDK time package.
+type Clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+	After(d time.Duration) <-chan time.Time
+	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
+	NewTicker(d time.Duration) Ticker
+	Tick(d time.Duration) <-chan time.Time
+	Wait4Scheduled(n int, timeout time.Duration) bool
+}

--- a/v3/clock/clock_test.go
+++ b/v3/clock/clock_test.go
@@ -1,0 +1,11 @@
+package clock
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}

--- a/v3/clock/duration.go
+++ b/v3/clock/duration.go
@@ -1,0 +1,66 @@
+package clock
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type DurationJSON struct {
+	Duration Duration
+}
+
+func NewDurationJSON(v interface{}) (DurationJSON, error) {
+	switch v := v.(type) {
+	case Duration:
+		return DurationJSON{Duration: v}, nil
+	case float64:
+		return DurationJSON{Duration: Duration(v)}, nil
+	case int64:
+		return DurationJSON{Duration: Duration(v)}, nil
+	case int:
+		return DurationJSON{Duration: Duration(v)}, nil
+	case []byte:
+		duration, err := ParseDuration(string(v))
+		if err != nil {
+			return DurationJSON{}, errors.Wrap(err, "while parsing []byte")
+		}
+		return DurationJSON{Duration: duration}, nil
+	case string:
+		duration, err := ParseDuration(v)
+		if err != nil {
+			return DurationJSON{}, errors.Wrap(err, "while parsing string")
+		}
+		return DurationJSON{Duration: duration}, nil
+	default:
+		return DurationJSON{}, errors.Errorf("bad type %T", v)
+	}
+}
+
+func NewDurationJSONOrPanic(v interface{}) DurationJSON {
+	d, err := NewDurationJSON(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func (d DurationJSON) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Duration.String())
+}
+
+func (d *DurationJSON) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	var err error
+
+	if err = json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	*d, err = NewDurationJSON(v)
+	return err
+}
+
+func (d DurationJSON) String() string {
+	return d.Duration.String()
+}

--- a/v3/clock/duration_test.go
+++ b/v3/clock/duration_test.go
@@ -1,0 +1,79 @@
+package clock_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mailgun/holster/v3/clock"
+	"github.com/stretchr/testify/suite"
+)
+
+type DurationSuite struct {
+	suite.Suite
+}
+
+func TestDurationSuite(t *testing.T) {
+	suite.Run(t, new(DurationSuite))
+}
+
+func (s *DurationSuite) TestNewOk() {
+	for _, v := range []interface{}{
+		42 * clock.Second,
+		int(42000000000),
+		int64(42000000000),
+		42000000000.,
+		"42s",
+		[]byte("42s"),
+	} {
+		d, err := clock.NewDurationJSON(v)
+		s.Nil(err)
+		s.Equal(42*clock.Second, d.Duration)
+	}
+}
+
+func (s *DurationSuite) TestNewError() {
+	for _, tc := range []struct {
+		v      interface{}
+		errMsg string
+	}{{
+		v:      "foo",
+		errMsg: "while parsing string: time: invalid duration foo",
+	}, {
+		v:      []byte("foo"),
+		errMsg: "while parsing []byte: time: invalid duration foo",
+	}, {
+		v:      true,
+		errMsg: "bad type bool",
+	}} {
+		d, err := clock.NewDurationJSON(tc.v)
+		s.Equal(tc.errMsg, err.Error())
+		s.Equal(clock.DurationJSON{}, d)
+	}
+}
+
+func (s *DurationSuite) TestUnmarshal() {
+	for _, v := range []string{
+		`{"foo": 42000000000}`,
+		`{"foo": 0.42e11}`,
+		`{"foo": "42s"}`,
+	} {
+		var withDuration struct {
+			Foo clock.DurationJSON `json:"foo"`
+		}
+		err := json.Unmarshal([]byte(v), &withDuration)
+		s.Nil(err)
+		s.Equal(42*clock.Second, withDuration.Foo.Duration)
+	}
+}
+
+func (s *DurationSuite) TestMarshalling() {
+	d, err := clock.NewDurationJSON(42 * clock.Second)
+	s.Nil(err)
+	encoded, err := d.MarshalJSON()
+	s.Nil(err)
+	var decoded clock.DurationJSON
+	err = decoded.UnmarshalJSON(encoded)
+	s.Nil(err)
+	s.Equal(d, decoded)
+	s.Equal("42s", decoded.String())
+}

--- a/v3/clock/frozen.go
+++ b/v3/clock/frozen.go
@@ -1,0 +1,232 @@
+package clock
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type frozenTime struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*frozenTimer
+	waiter *waiter
+}
+
+type waiter struct {
+	count    int
+	signalCh chan struct{}
+}
+
+func (ft *frozenTime) Now() time.Time {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	return ft.now
+}
+
+func (ft *frozenTime) Sleep(d time.Duration) {
+	<-ft.NewTimer(d).C()
+}
+
+func (ft *frozenTime) After(d time.Duration) <-chan time.Time {
+	return ft.NewTimer(d).C()
+}
+
+func (ft *frozenTime) NewTimer(d time.Duration) Timer {
+	return ft.AfterFunc(d, nil)
+}
+
+func (ft *frozenTime) AfterFunc(d time.Duration, f func()) Timer {
+	t := &frozenTimer{
+		ft:   ft,
+		when: ft.Now().Add(d),
+		f:    f,
+	}
+	if f == nil {
+		t.c = make(chan time.Time, 1)
+	}
+	ft.startTimer(t)
+	return t
+}
+
+func (ft *frozenTime) advance(d time.Duration) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	ft.now = ft.now.Add(d)
+	for t := ft.nextExpired(); t != nil; t = ft.nextExpired() {
+		// Send the timer expiration time to the timer channel if it is
+		// defined. But make sure not to block on the send if the channel is
+		// full. This behavior will make a ticker skip beats if it readers are
+		// not fast enough.
+		if t.c != nil {
+			select {
+			case t.c <- t.when:
+			default:
+			}
+		}
+		// If it is a ticking timer then schedule next tick, otherwise mark it
+		// as stopped.
+		if t.interval != 0 {
+			t.when = t.when.Add(t.interval)
+			t.stopped = false
+			ft.unlockedStartTimer(t)
+		}
+		// If a function is associated with the timer then call it, but make
+		// sure to release the lock for the time of call it is necessary
+		// because the lock is not re-entrant but the function may need to
+		// start another timer or ticker.
+		if t.f != nil {
+			func() {
+				ft.mu.Unlock()
+				defer ft.mu.Lock()
+				t.f()
+			}()
+		}
+	}
+}
+
+func (ft *frozenTime) stopTimer(t *frozenTimer) bool {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	if t.stopped {
+		return false
+	}
+	for i, curr := range ft.timers {
+		if curr == t {
+			t.stopped = true
+			copy(ft.timers[i:], ft.timers[i+1:])
+			lastIdx := len(ft.timers) - 1
+			ft.timers[lastIdx] = nil
+			ft.timers = ft.timers[:lastIdx]
+			return true
+		}
+	}
+	return false
+}
+
+func (ft *frozenTime) nextExpired() *frozenTimer {
+	if len(ft.timers) == 0 {
+		return nil
+	}
+	t := ft.timers[0]
+	if ft.now.Before(t.when) {
+		return nil
+	}
+	copy(ft.timers, ft.timers[1:])
+	lastIdx := len(ft.timers) - 1
+	ft.timers[lastIdx] = nil
+	ft.timers = ft.timers[:lastIdx]
+	t.stopped = true
+	return t
+}
+
+func (ft *frozenTime) startTimer(t *frozenTimer) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	ft.unlockedStartTimer(t)
+
+	if ft.waiter == nil {
+		return
+	}
+	if len(ft.timers) >= ft.waiter.count {
+		close(ft.waiter.signalCh)
+	}
+}
+
+func (ft *frozenTime) unlockedStartTimer(t *frozenTimer) {
+	pos := 0
+	for _, curr := range ft.timers {
+		if t.when.Before(curr.when) {
+			break
+		}
+		pos++
+	}
+	ft.timers = append(ft.timers, nil)
+	copy(ft.timers[pos+1:], ft.timers[pos:])
+	ft.timers[pos] = t
+}
+
+type frozenTimer struct {
+	ft       *frozenTime
+	when     time.Time
+	interval time.Duration
+	stopped  bool
+	c        chan time.Time
+	f        func()
+}
+
+func (t *frozenTimer) C() <-chan time.Time {
+	return t.c
+}
+
+func (t *frozenTimer) Stop() bool {
+	return t.ft.stopTimer(t)
+}
+
+func (t *frozenTimer) Reset(d time.Duration) bool {
+	active := t.ft.stopTimer(t)
+	t.when = t.ft.Now().Add(d)
+	t.ft.startTimer(t)
+	return active
+}
+
+type frozenTicker struct {
+	t *frozenTimer
+}
+
+func (t *frozenTicker) C() <-chan time.Time {
+	return t.t.C()
+}
+
+func (t *frozenTicker) Stop() {
+	t.t.Stop()
+}
+
+func (ft *frozenTime) NewTicker(d time.Duration) Ticker {
+	if d <= 0 {
+		panic(errors.New("non-positive interval for NewTicker"))
+	}
+	t := &frozenTimer{
+		ft:       ft,
+		when:     ft.Now().Add(d),
+		interval: d,
+		c:        make(chan time.Time, 1),
+	}
+	ft.startTimer(t)
+	return &frozenTicker{t}
+}
+
+func (ft *frozenTime) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	return ft.NewTicker(d).C()
+}
+
+func (ft *frozenTime) Wait4Scheduled(count int, timeout time.Duration) bool {
+	ft.mu.Lock()
+	if len(ft.timers) >= count {
+		ft.mu.Unlock()
+		return true
+	}
+	if ft.waiter != nil {
+		panic("Concurrent call")
+	}
+	ft.waiter = &waiter{count, make(chan struct{})}
+	ft.mu.Unlock()
+
+	success := false
+	select {
+	case <-ft.waiter.signalCh:
+		success = true
+	case <-time.After(timeout):
+	}
+	ft.mu.Lock()
+	ft.waiter = nil
+	ft.mu.Unlock()
+	return success
+}

--- a/v3/clock/frozen_test.go
+++ b/v3/clock/frozen_test.go
@@ -1,0 +1,331 @@
+package clock
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestFreezeUnfreeze(t *testing.T) {
+	defer Freeze(Now()).Unfreeze()
+}
+
+type FrozenSuite struct {
+	epoch time.Time
+}
+
+var _ = Suite(&FrozenSuite{})
+
+func (s *FrozenSuite) SetUpSuite(c *C) {
+	var err error
+	s.epoch, err = time.Parse(time.RFC3339, "2009-02-19T00:00:00Z")
+	c.Assert(err, IsNil)
+}
+
+func (s *FrozenSuite) SetUpTest(c *C) {
+	Freeze(s.epoch)
+}
+
+func (s *FrozenSuite) TearDownTest(c *C) {
+	Unfreeze()
+}
+
+func (s *FrozenSuite) TestAdvanceNow(c *C) {
+	c.Assert(Now(), Equals, s.epoch)
+	c.Assert(Advance(42*time.Millisecond), Equals, 42*time.Millisecond)
+	c.Assert(Now(), Equals, s.epoch.Add(42*time.Millisecond))
+	c.Assert(Advance(13*time.Millisecond), Equals, 55*time.Millisecond)
+	c.Assert(Advance(19*time.Millisecond), Equals, 74*time.Millisecond)
+	c.Assert(Now(), Equals, s.epoch.Add(74*time.Millisecond))
+}
+
+func (s *FrozenSuite) TestSleep(c *C) {
+	hits := make(chan int, 100)
+
+	delays := []int{60, 100, 90, 131, 999, 5}
+	for i, tc := range []struct {
+		desc string
+		fn   func(delayMs int)
+	}{{
+		desc: "Sleep",
+		fn: func(delay int) {
+			Sleep(time.Duration(delay) * time.Millisecond)
+			hits <- delay
+		},
+	}, {
+		desc: "After",
+		fn: func(delay int) {
+			<-After(time.Duration(delay) * time.Millisecond)
+			hits <- delay
+		},
+	}, {
+		desc: "AfterFunc",
+		fn: func(delay int) {
+			AfterFunc(time.Duration(delay)*time.Millisecond,
+				func() {
+					hits <- delay
+				})
+		},
+	}, {
+		desc: "NewTimer",
+		fn: func(delay int) {
+			t := NewTimer(time.Duration(delay) * time.Millisecond)
+			<-t.C()
+			hits <- delay
+		},
+	}} {
+		fmt.Printf("Test case #%d: %s", i, tc.desc)
+		for _, delay := range delays {
+			go tc.fn(delay)
+		}
+		// Spin-wait for all goroutines to fall asleep.
+		ft := provider.(*frozenTime)
+		for {
+			if len(ft.timers) == len(delays) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		runningMs := 0
+		for i, delayMs := range []int{5, 60, 90, 100, 131, 999} {
+			fmt.Printf("Checking timer #%d, delay=%d\n", i, delayMs)
+			delta := delayMs - runningMs - 1
+			Advance(time.Duration(delta) * time.Millisecond)
+			// Check before each timer deadline that it is not triggered yet.
+			assertHits(c, hits, []int{})
+
+			// When
+			Advance(1 * time.Millisecond)
+
+			// Then
+			assertHits(c, hits, []int{delayMs})
+
+			runningMs += delta + 1
+		}
+
+		Advance(1000 * time.Millisecond)
+		assertHits(c, hits, []int{})
+	}
+}
+
+// Timers scheduled to trigger at the same time do that in the order they were
+// created.
+func (s *FrozenSuite) TestSameTime(c *C) {
+	var hits []int
+
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	AfterFunc(100, func() { hits = append(hits, 1) })
+	AfterFunc(99, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 5) })
+	AfterFunc(101, func() { hits = append(hits, 4) })
+	AfterFunc(101, func() { hits = append(hits, 6) })
+
+	// When
+	Advance(100)
+
+	// Then
+	c.Assert(hits, DeepEquals, []int{2, 3, 1, 5})
+}
+
+func (s *FrozenSuite) TestTimerStop(c *C) {
+	hits := []int{}
+
+	AfterFunc(100, func() { hits = append(hits, 1) })
+	t := AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	Advance(99)
+	c.Assert(hits, DeepEquals, []int{})
+
+	// When
+	active1 := t.Stop()
+	active2 := t.Stop()
+
+	// Then
+	c.Assert(active1, Equals, true)
+	c.Assert(active2, Equals, false)
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{1, 3})
+}
+
+func (s *FrozenSuite) TestReset(c *C) {
+	hits := []int{}
+
+	t1 := AfterFunc(100, func() { hits = append(hits, 1) })
+	t2 := AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	Advance(99)
+	c.Assert(hits, DeepEquals, []int{})
+
+	// When
+	active1 := t1.Reset(1) // Reset to the same time
+	active2 := t2.Reset(7)
+
+	// Then
+	c.Assert(active1, Equals, true)
+	c.Assert(active2, Equals, true)
+
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{3, 1})
+	Advance(5)
+	c.Assert(hits, DeepEquals, []int{3, 1})
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{3, 1, 2})
+}
+
+// Reset to the same time just puts the timer at the end of the trigger list
+// for the date.
+func (s *FrozenSuite) TestResetSame(c *C) {
+	hits := []int{}
+
+	t := AfterFunc(100, func() { hits = append(hits, 1) })
+	AfterFunc(100, func() { hits = append(hits, 2) })
+	AfterFunc(100, func() { hits = append(hits, 3) })
+	AfterFunc(101, func() { hits = append(hits, 4) })
+	Advance(9)
+
+	// When
+	active := t.Reset(91)
+
+	// Then
+	c.Assert(active, Equals, true)
+
+	Advance(90)
+	c.Assert(hits, DeepEquals, []int{})
+	Advance(1)
+	c.Assert(hits, DeepEquals, []int{2, 3, 1})
+}
+
+func (s *FrozenSuite) TestTicker(c *C) {
+	t := NewTicker(100)
+
+	Advance(99)
+	assertNotFired(c, t.C())
+	Advance(1)
+	c.Assert(s.epoch.Add(100), Equals, <-t.C())
+	Advance(750)
+	c.Assert(s.epoch.Add(200), Equals, <-t.C())
+	Advance(49)
+	assertNotFired(c, t.C())
+	Advance(1)
+	c.Assert(s.epoch.Add(900), Equals, <-t.C())
+
+	t.Stop()
+	Advance(300)
+	assertNotFired(c, t.C())
+}
+
+func (s *FrozenSuite) TestTickerZero(c *C) {
+	defer func() {
+		recover()
+	}()
+
+	NewTicker(0)
+	c.Error("Should panic")
+}
+
+func (s *FrozenSuite) TestTick(c *C) {
+	ch := Tick(100)
+
+	Advance(99)
+	assertNotFired(c, ch)
+	Advance(1)
+	c.Assert(s.epoch.Add(100), Equals, <-ch)
+	Advance(750)
+	c.Assert(s.epoch.Add(200), Equals, <-ch)
+	Advance(49)
+	assertNotFired(c, ch)
+	Advance(1)
+	c.Assert(s.epoch.Add(900), Equals, <-ch)
+}
+
+func (s *FrozenSuite) TestTickZero(c *C) {
+	ch := Tick(0)
+	c.Assert(ch, IsNil)
+}
+
+func (s *FrozenSuite) TestNewStoppedTimer(c *C) {
+	t := NewStoppedTimer()
+
+	// When/Then
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+	c.Assert(t.Stop(), Equals, false)
+}
+
+func (s *FrozenSuite) TestWait4Scheduled(c *C) {
+	After(100 * Millisecond)
+	After(100 * Millisecond)
+	c.Assert(Wait4Scheduled(3, 0), Equals, false)
+
+	startedCh := make(chan struct{})
+	resultCh := make(chan bool)
+	go func() {
+		close(startedCh)
+		resultCh <- Wait4Scheduled(3, 5*Second)
+	}()
+	// Allow some time for waiter to be set and start waiting for a signal.
+	<-startedCh
+	time.Sleep(50 * Millisecond)
+
+	// When
+	After(100 * Millisecond)
+
+	// Then
+	c.Assert(<-resultCh, Equals, true)
+}
+
+// If there is enough timers scheduled already, then a shortcut execution path
+// is taken and Wait4Scheduled returns immediately.
+func (s *FrozenSuite) TestWait4ScheduledImmediate(c *C) {
+	After(100 * Millisecond)
+	After(100 * Millisecond)
+	// When/Then
+	c.Assert(Wait4Scheduled(2, 0), Equals, true)
+}
+
+func (s *FrozenSuite) TestSince(c *C) {
+	c.Assert(Since(Now()), Equals, Duration(0))
+	c.Assert(Since(Now().Add(Millisecond)), Equals, -Millisecond)
+	c.Assert(Since(Now().Add(-Millisecond)), Equals, Millisecond)
+}
+
+func (s *FrozenSuite) TestUntil(c *C) {
+	c.Assert(Until(Now()), Equals, Duration(0))
+	c.Assert(Until(Now().Add(Millisecond)), Equals, Millisecond)
+	c.Assert(Until(Now().Add(-Millisecond)), Equals, -Millisecond)
+}
+
+func assertHits(c *C, got <-chan int, want []int) {
+	for i, w := range want {
+		var g int
+		select {
+		case g = <-got:
+		case <-time.After(100 * time.Millisecond):
+			c.Errorf("Missing hit: want=%v", w)
+			return
+		}
+		c.Assert(g, Equals, w, Commentf("Hit #%d", i))
+	}
+	for {
+		select {
+		case g := <-got:
+			c.Errorf("Unexpected hit: %v", g)
+		default:
+			return
+		}
+	}
+}
+
+func assertNotFired(c *C, ch <-chan time.Time) {
+	select {
+	case <-ch:
+		c.Error("Premature fire")
+	default:
+	}
+}

--- a/v3/clock/go19.go
+++ b/v3/clock/go19.go
@@ -1,0 +1,106 @@
+// +build go1.9
+
+// This file introduces aliases to allow using of the clock package as a
+// drop-in replacement of the standard time package.
+
+package clock
+
+import "time"
+
+type (
+	Time     = time.Time
+	Duration = time.Duration
+	Location = time.Location
+
+	Weekday = time.Weekday
+	Month   = time.Month
+
+	ParseError = time.ParseError
+)
+
+const (
+	Nanosecond  = time.Nanosecond
+	Microsecond = time.Microsecond
+	Millisecond = time.Millisecond
+	Second      = time.Second
+	Minute      = time.Minute
+	Hour        = time.Hour
+
+	Sunday    = time.Sunday
+	Monday    = time.Monday
+	Tuesday   = time.Tuesday
+	Wednesday = time.Wednesday
+	Thursday  = time.Thursday
+	Friday    = time.Friday
+	Saturday  = time.Saturday
+
+	January   = time.January
+	February  = time.February
+	March     = time.March
+	April     = time.April
+	May       = time.May
+	June      = time.June
+	July      = time.July
+	August    = time.August
+	September = time.September
+	October   = time.October
+	November  = time.November
+	December  = time.December
+
+	ANSIC       = time.ANSIC
+	UnixDate    = time.UnixDate
+	RubyDate    = time.RubyDate
+	RFC822      = time.RFC822
+	RFC822Z     = time.RFC822Z
+	RFC850      = time.RFC850
+	RFC1123     = time.RFC1123
+	RFC1123Z    = time.RFC1123Z
+	RFC3339     = time.RFC3339
+	RFC3339Nano = time.RFC3339Nano
+	Kitchen     = time.Kitchen
+	Stamp       = time.Stamp
+	StampMilli  = time.StampMilli
+	StampMicro  = time.StampMicro
+	StampNano   = time.StampNano
+)
+
+var (
+	UTC   = time.UTC
+	Local = time.Local
+)
+
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time {
+	return time.Date(year, month, day, hour, min, sec, nsec, loc)
+}
+
+func FixedZone(name string, offset int) *Location {
+	return time.FixedZone(name, offset)
+}
+
+func LoadLocation(name string) (*Location, error) {
+	return time.LoadLocation(name)
+}
+
+func Parse(layout, value string) (Time, error) {
+	return time.Parse(layout, value)
+}
+
+func ParseDuration(s string) (Duration, error) {
+	return time.ParseDuration(s)
+}
+
+func ParseInLocation(layout, value string, loc *Location) (Time, error) {
+	return time.ParseInLocation(layout, value, loc)
+}
+
+func Unix(sec int64, nsec int64) Time {
+	return time.Unix(sec, nsec)
+}
+
+func Since(t Time) Duration {
+	return provider.Now().Sub(t)
+}
+
+func Until(t Time) Duration {
+	return t.Sub(provider.Now())
+}

--- a/v3/clock/rfc822.go
+++ b/v3/clock/rfc822.go
@@ -1,0 +1,47 @@
+package clock
+
+import (
+	"strconv"
+)
+
+// Allows seamless JSON encoding/decoding of rfc822 formatted timestamps.
+// https://www.ietf.org/rfc/rfc822.txt section 5.
+type RFC822Time struct {
+	Time
+}
+
+// NewRFC822Time creates RFC822Time from a standard Time. The created value is
+// truncated down to second precision because RFC822 does not allow for better.
+func NewRFC822Time(t Time) RFC822Time {
+	return RFC822Time{Time: t.Truncate(Second)}
+}
+
+// NewRFC822Time creates RFC822Time from a Unix timestamp (seconds from Epoch).
+func NewRFC822TimeFromUnix(timestamp int64) RFC822Time {
+	return RFC822Time{Time: Unix(timestamp, 0).UTC()}
+}
+
+func (t RFC822Time) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(t.Format(RFC1123))), nil
+}
+
+func (t *RFC822Time) UnmarshalJSON(s []byte) error {
+	q, err := strconv.Unquote(string(s))
+	if err != nil {
+		return err
+	}
+	if t.Time, err = Parse(RFC1123, q); err == nil {
+		return nil
+	}
+	if err, ok := err.(*ParseError); !ok || err.LayoutElem != "MST" {
+		return err
+	}
+	if t.Time, err = Parse(RFC1123Z, q); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t RFC822Time) String() string {
+	return t.Format(RFC1123)
+}

--- a/v3/clock/rfc822_test.go
+++ b/v3/clock/rfc822_test.go
@@ -1,0 +1,116 @@
+package clock
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	Time RFC822Time `json:"ts"`
+}
+
+func TestRFC822New(t *testing.T) {
+	stdTime, err := Parse(RFC3339, "2019-08-29T11:20:07.123456+03:00")
+	assert.NoError(t, err)
+
+	rfc822TimeFromTime := NewRFC822Time(stdTime)
+	rfc822TimeFromUnix := NewRFC822TimeFromUnix(stdTime.Unix())
+	assert.True(t, rfc822TimeFromTime.Equal(rfc822TimeFromUnix.Time),
+		"want=%s, got=%s", rfc822TimeFromTime.Time, rfc822TimeFromUnix.Time)
+
+	assert.Equal(t, "Thu, 29 Aug 2019 11:20:07 MSK", rfc822TimeFromTime.String())
+	assert.Equal(t, "Thu, 29 Aug 2019 08:20:07 UTC", rfc822TimeFromUnix.String())
+}
+
+// NewRFC822Time truncates to second precision.
+func TestRFC822SecondPrecision(t *testing.T) {
+	stdTime1, err := Parse(RFC3339, "2019-08-29T11:20:07.111111+03:00")
+	assert.NoError(t, err)
+	stdTime2, err := Parse(RFC3339, "2019-08-29T11:20:07.999999+03:00")
+	assert.NoError(t, err)
+	assert.False(t, stdTime1.Equal(stdTime2))
+
+	rfc822Time1 := NewRFC822Time(stdTime1)
+	rfc822Time2 := NewRFC822Time(stdTime2)
+	assert.True(t, rfc822Time1.Equal(rfc822Time2.Time),
+		"want=%s, got=%s", rfc822Time1.Time, rfc822Time2.Time)
+}
+
+// Marshaled representation is truncated down to second precision.
+func TestRFC822Marshaling(t *testing.T) {
+	stdTime, err := Parse(RFC3339Nano, "2019-08-29T11:20:07.123456789+03:30")
+	assert.NoError(t, err)
+
+	ts := testStruct{Time: NewRFC822Time(stdTime)}
+	encoded, err := json.Marshal(&ts)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"ts":"Thu, 29 Aug 2019 11:20:07 +0330"}`, string(encoded))
+}
+
+func TestRFC822Unmarshaling(t *testing.T) {
+	for i, tc := range []struct {
+		inRFC822   string
+		outRFC3339 string
+		outRFC822  string
+	}{{
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 GMT",
+		outRFC3339: "2019-08-29T11:20:07Z",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 GMT",
+	}, {
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 MSK",
+		outRFC3339: "2019-08-29T11:20:07+03:00",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 MSK",
+	}, {
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 -0000",
+		outRFC3339: "2019-08-29T11:20:07Z",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 -0000",
+	}, {
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 +0000",
+		outRFC3339: "2019-08-29T11:20:07Z",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 +0000",
+	}, {
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 +0300",
+		outRFC3339: "2019-08-29T11:20:07+03:00",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 MSK",
+	}, {
+		inRFC822:   "Thu, 29 Aug 2019 11:20:07 +0330",
+		outRFC3339: "2019-08-29T11:20:07+03:30",
+		outRFC822:  "Thu, 29 Aug 2019 11:20:07 +0330",
+	}} {
+		tcDesc := fmt.Sprintf("Test case #%d: %v", i, tc)
+		var ts testStruct
+
+		inEncoded := []byte(fmt.Sprintf(`{"ts":"%s"}`, tc.inRFC822))
+		err := json.Unmarshal(inEncoded, &ts)
+		assert.NoError(t, err, tcDesc)
+		assert.Equal(t, tc.outRFC3339, ts.Time.Format(RFC3339), tcDesc)
+
+		actualEncoded, err := json.Marshal(&ts)
+		assert.NoError(t, err, tcDesc)
+		outEncoded := fmt.Sprintf(`{"ts":"%s"}`, tc.outRFC822)
+		assert.Equal(t, outEncoded, string(actualEncoded), tcDesc)
+	}
+}
+
+func TestRFC822UnmarshalingError(t *testing.T) {
+	for _, tc := range []struct {
+		inEncoded string
+		outError  string
+	}{{
+		inEncoded: `{"ts": "Thu, 29 Aug 2019 11:20:07"}`,
+		outError:  `parsing time "Thu, 29 Aug 2019 11:20:07" as "Mon, 02 Jan 2006 15:04:05 -0700": cannot parse "" as "-0700"`,
+	}, {
+		inEncoded: `{"ts": "foo"}`,
+		outError:  `parsing time "foo" as "Mon, 02 Jan 2006 15:04:05 MST": cannot parse "foo" as "Mon"`,
+	}, {
+		inEncoded: `{"ts": 42}`,
+		outError:  "invalid syntax",
+	}} {
+		var ts testStruct
+		err := json.Unmarshal([]byte(tc.inEncoded), &ts)
+		assert.EqualError(t, err, tc.outError)
+	}
+}

--- a/v3/clock/system.go
+++ b/v3/clock/system.go
@@ -1,0 +1,68 @@
+package clock
+
+import "time"
+
+type systemTime struct{}
+
+func (st *systemTime) Now() time.Time {
+	return time.Now()
+}
+
+func (st *systemTime) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (st *systemTime) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+type systemTimer struct {
+	t *time.Timer
+}
+
+func (st *systemTime) NewTimer(d time.Duration) Timer {
+	t := time.NewTimer(d)
+	return &systemTimer{t}
+}
+
+func (st *systemTime) AfterFunc(d time.Duration, f func()) Timer {
+	t := time.AfterFunc(d, f)
+	return &systemTimer{t}
+}
+
+func (t *systemTimer) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *systemTimer) Stop() bool {
+	return t.t.Stop()
+}
+
+func (t *systemTimer) Reset(d time.Duration) bool {
+	return t.t.Reset(d)
+}
+
+type systemTicker struct {
+	t *time.Ticker
+}
+
+func (t *systemTicker) C() <-chan time.Time {
+	return t.t.C
+}
+
+func (t *systemTicker) Stop() {
+	t.t.Stop()
+}
+
+func (st *systemTime) NewTicker(d time.Duration) Ticker {
+	t := time.NewTicker(d)
+	return &systemTicker{t}
+}
+
+func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
+	return time.Tick(d)
+}
+
+func (st *systemTime) Wait4Scheduled(count int, timeout time.Duration) bool {
+	panic("Not supported")
+}

--- a/v3/clock/system_test.go
+++ b/v3/clock/system_test.go
@@ -1,0 +1,146 @@
+package clock
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type SystemSuite struct{}
+
+var _ = Suite(&SystemSuite{})
+
+func (s *SystemSuite) TestSleep(c *C) {
+	start := Now()
+
+	// When
+	Sleep(100 * time.Millisecond)
+
+	// Then
+	if Now().Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestAfter(c *C) {
+	start := Now()
+
+	// When
+	end := <-After(100 * time.Millisecond)
+
+	// Then
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestAfterFunc(c *C) {
+	start := Now()
+	endCh := make(chan time.Time, 1)
+
+	// When
+	AfterFunc(100*time.Millisecond, func() { endCh <- time.Now() })
+
+	// Then
+	end := <-endCh
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestNewTimer(c *C) {
+	start := Now()
+
+	// When
+	t := NewTimer(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestTimerStop(c *C) {
+	t := NewTimer(50 * time.Millisecond)
+
+	// When
+	active := t.Stop()
+
+	// Then
+	c.Assert(active, Equals, true)
+	time.Sleep(100)
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+}
+
+func (s *SystemSuite) TestTimerReset(c *C) {
+	start := time.Now()
+	t := NewTimer(300 * time.Millisecond)
+
+	// When
+	t.Reset(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) > 150*time.Millisecond {
+		c.Error("Waited too long")
+	}
+}
+
+func (s *SystemSuite) TestNewTicker(c *C) {
+	start := Now()
+
+	// When
+	t := NewTicker(100 * time.Millisecond)
+
+	// Then
+	end := <-t.C()
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+	end = <-t.C()
+	if end.Sub(start) < 200*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+
+	t.Stop()
+	time.Sleep(150)
+	select {
+	case <-t.C():
+		c.Error("Ticker should not have fired")
+	default:
+	}
+}
+
+func (s *SystemSuite) TestTick(c *C) {
+	start := Now()
+
+	// When
+	ch := Tick(100 * time.Millisecond)
+
+	// Then
+	end := <-ch
+	if end.Sub(start) < 100*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+	end = <-ch
+	if end.Sub(start) < 200*time.Millisecond {
+		c.Error("Sleep did not last long enough")
+	}
+}
+
+func (s *SystemSuite) TestNewStoppedTimer(c *C) {
+	t := NewStoppedTimer()
+
+	// When/Then
+	select {
+	case <-t.C():
+		c.Error("Timer should not have fired")
+	default:
+	}
+	c.Assert(t.Stop(), Equals, false)
+}

--- a/v3/etcdutil/README.md
+++ b/v3/etcdutil/README.md
@@ -1,0 +1,134 @@
+## NewElection()
+Use etcd for leader election if you have several instances of a service running in production
+and you only want one of the service instances to preform a task.
+
+`LeaderElection` starts a goroutine which performs an election and maintains a leader
+while candidates join and leave the election. Calling `Close()` will concede leadership if
+the service currently has it and will withdraw the candidate from the election.
+
+```go
+
+import (
+    "github.com/mailgun/holster"
+    "github.com/mailgun/holster/etcdutil"
+)
+
+func main() {
+    var wg holster.WaitGroup
+
+    client, err := etcdutil.NewClient(nil)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "while creating etcd client: %s\n", err)
+        return
+    }
+    
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+    // Start a leader election and attempt to become leader, only returns after
+    // determining the current leader.
+	election := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
+		Election:                "my-service",
+		Candidate:               "my-candidate",
+		EventObserver: func(e etcdutil.Event) {
+			leaderChan <- e
+			if e.IsDone {
+				close(leaderChan)
+			}
+		},
+		TTL: 10,
+	})
+
+    // Handle graceful shutdown
+    signalChan := make(chan os.Signal, 1)
+    signal.Notify(signalChan, os.Interrupt, os.Kill)
+
+    // Do periodic thing
+    tick := time.NewTicker(time.Second * 2)
+    wg.Loop(func() bool {
+        select {
+        case <-tick.C:
+            // Are we currently leader?
+            if election.IsLeader() {
+                err := DoThing()
+                if err != nil {
+                    // Have another instance run DoThing()
+                    // since we can't for some reason.
+                    election.Concede()
+                }
+            }
+            return true
+        case <-signalChan:
+            election.Stop()
+            return false
+        }
+    })
+    wg.Wait()
+    
+    // Or you can pipe events to a channel
+    for leader := range leaderChan {
+    	fmt.Printf("Leader: %v\n", leader)
+    }
+}
+```
+
+## NewConfig()
+Designed to be used in applications that share the same etcd config
+and wish to reuse the same config throughout the application.
+
+```go
+import (
+    "os"
+    "fmt"
+
+    "github.com/mailgun/holster/etcdutil"
+)
+
+func main() {
+    // These environment variables provided by the environment,
+    // we set them here to only to illustrate how `NewConfig()`
+    // uses the environment to create a new etcd config
+    os.Setenv("ETCD3_USER", "root")
+    os.Setenv("ETCD3_PASSWORD", "rootpw")
+    os.Setenv("ETCD3_ENDPOINT", "etcd-n01:2379,etcd-n02:2379,etcd-n03:2379")
+
+    // These default to /etc/mailgun/ssl/localhost/etcd-xxx.pem if the files exist
+    os.Setenv("ETCD3_TLS_CERT", "/path/to/etcd-cert.pem")
+    os.Setenv("ETCD3_TLS_KEY", "/path/to/etcd-key.pem")
+    os.Setenv("ETCD3_CA", "/path/to/etcd-ca.pem")
+    
+    // Set this to force connecting with TLS, but without cert verification
+    os.Setenv("ETCD3_SKIP_VERIFY", "true")
+
+    // Create a new etc config from available environment variables
+    cfg, err := etcdutil.NewConfig(nil)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "while creating etcd config: %s\n", err)
+        return
+    }
+}
+```
+
+## NewClient()
+Just like `NewConfig()` but returns a connected etcd client for use by the
+rest of the application.
+
+```go
+import (
+    "os"
+    "fmt"
+
+    "github.com/mailgun/holster/etcdutil"
+)
+
+func main() {
+    // Create a new etc client from available environment variables
+    client, err := etcdutil.NewClient(nil)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "while creating etcd client: %s\n", err)
+        return
+    }
+
+    // Use client
+}
+```

--- a/v3/etcdutil/config.go
+++ b/v3/etcdutil/config.go
@@ -1,0 +1,116 @@
+package etcdutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/grpclog"
+)
+
+const (
+	localEtcdEndpoint = "127.0.0.1:2379"
+)
+
+func init() {
+	// We check this here to avoid data race with GRPC go routines writing to the logger
+	if os.Getenv("ETCD3_DEBUG") != "" {
+		etcd.SetLogger(grpclog.NewLoggerV2WithVerbosity(os.Stderr, os.Stderr, os.Stderr, 4))
+	}
+}
+
+// NewClient creates a new etcd.Client with the specified config where blanks
+// are filled from environment variables by NewConfig.
+//
+// If the provided config is nil and no environment variables are set, it will
+// return a client connecting without TLS via localhost:2379.
+func NewClient(cfg *etcd.Config) (*etcd.Client, error) {
+	var err error
+	if cfg, err = NewConfig(cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to build etcd config")
+	}
+
+	etcdClt, err := etcd.New(*cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create etcd client")
+	}
+	return etcdClt, nil
+}
+
+// NewConfig creates a new etcd.Config using environment variables. If an
+// existing config is passed, it will fill in missing configuration using
+// environment variables or defaults if they exists on the local system.
+//
+// If no environment variables are set, it will return a config set to
+// connect without TLS via localhost:2379.
+func NewConfig(cfg *etcd.Config) (*etcd.Config, error) {
+	var envEndpoint, tlsCertFile, tlsKeyFile, tlsCAFile string
+
+	holster.SetDefault(&cfg, &etcd.Config{})
+	holster.SetDefault(&cfg.Username, os.Getenv("ETCD3_USER"))
+	holster.SetDefault(&cfg.Password, os.Getenv("ETCD3_PASSWORD"))
+	holster.SetDefault(&tlsCertFile, os.Getenv("ETCD3_TLS_CERT"))
+	holster.SetDefault(&tlsKeyFile, os.Getenv("ETCD3_TLS_KEY"))
+	holster.SetDefault(&tlsCAFile, os.Getenv("ETCD3_CA"))
+
+	// Default to 5 second timeout, else connections hang indefinitely
+	holster.SetDefault(&cfg.DialTimeout, time.Second*5)
+	// Or if the user provided a timeout
+	if timeout := os.Getenv("ETCD3_DIAL_TIMEOUT"); timeout != "" {
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return nil, errors.Errorf(
+				"ETCD3_DIAL_TIMEOUT='%s' is not a duration (1m|15s|24h): %s", timeout, err)
+		}
+		cfg.DialTimeout = duration
+	}
+
+	// If the CA file was provided
+	if tlsCAFile != "" {
+		holster.SetDefault(&cfg.TLS, &tls.Config{})
+
+		var certPool *x509.CertPool = nil
+		if pemBytes, err := ioutil.ReadFile(tlsCAFile); err == nil {
+			certPool = x509.NewCertPool()
+			certPool.AppendCertsFromPEM(pemBytes)
+		} else {
+			return nil, errors.Errorf("while loading cert CA file '%s': %s", tlsCAFile, err)
+		}
+		holster.SetDefault(&cfg.TLS.RootCAs, certPool)
+		cfg.TLS.InsecureSkipVerify = false
+	}
+
+	// If the cert and key files are provided attempt to load them
+	if tlsCertFile != "" && tlsKeyFile != "" {
+		holster.SetDefault(&cfg.TLS, &tls.Config{})
+		tlsCert, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+		if err != nil {
+			return nil, errors.Errorf("while loading cert '%s' and key file '%s': %s",
+				tlsCertFile, tlsKeyFile, err)
+		}
+		holster.SetDefault(&cfg.TLS.Certificates, []tls.Certificate{tlsCert})
+	}
+
+	holster.SetDefault(&envEndpoint, os.Getenv("ETCD3_ENDPOINT"), localEtcdEndpoint)
+	holster.SetDefault(&cfg.Endpoints, strings.Split(envEndpoint, ","))
+
+	// If no other TLS config is provided this will force connecting with TLS,
+	// without cert verification
+	if os.Getenv("ETCD3_SKIP_VERIFY") != "" {
+		holster.SetDefault(&cfg.TLS, &tls.Config{})
+		cfg.TLS.InsecureSkipVerify = true
+	}
+
+	// Enable TLS with no additional configuration
+	if os.Getenv("ETCD3_ENABLE_TLS") != "" {
+		holster.SetDefault(&cfg.TLS, &tls.Config{})
+	}
+
+	return cfg, nil
+}

--- a/v3/etcdutil/docker-compose.yaml
+++ b/v3/etcdutil/docker-compose.yaml
@@ -1,0 +1,28 @@
+# This setup is for testing only, all communication with 
+# etcd is done through the proxy. You have to create a proxy
+# with toxiproxy-cli before you can connect to etcd
+#
+# toxiproxy-cli create etcd --listen 0.0.0.0:2379 --upstream etcd:22379
+
+version: '3.2'
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.2
+    command: >
+        /usr/local/bin/etcd
+        -name etcd0
+        -advertise-client-urls http://localhost:2379
+        -listen-client-urls http://0.0.0.0:22379
+        -initial-advertise-peer-urls http://0.0.0.0:2381
+        -listen-peer-urls http://0.0.0.0:2381
+        -initial-cluster-token etcd-cluster-1
+        -initial-cluster etcd0=http://0.0.0.0:2381
+        -initial-cluster-state new
+        -enable-v2=false
+    ports:
+        - "22379:22379"
+#  proxy:
+#    image: shopify/toxiproxy:latest
+#    ports:
+#      - "2379:2379"
+#      - "8474:8474"

--- a/v3/etcdutil/election.go
+++ b/v3/etcdutil/election.go
@@ -1,0 +1,445 @@
+package etcdutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"sync/atomic"
+	"time"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/mailgun/holster"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Entry
+
+type LeaderElector interface {
+	IsLeader() bool
+	Concede() (bool, error)
+	Close()
+}
+
+var _ LeaderElector = &Election{}
+
+type Event struct {
+	// True if our candidate is leader
+	IsLeader bool
+	// True if the election is shutdown and
+	// no further events will follow.
+	IsDone bool
+	// Holds the current leader key
+	LeaderKey string
+	// Hold the current leaders data
+	LeaderData string
+	// If not nil, contains an error encountered
+	// while participating in the election.
+	Err error
+}
+
+type EventObserver func(Event)
+
+type Election struct {
+	observers map[string]EventObserver
+	backOff   *holster.BackOffCounter
+	cancel    context.CancelFunc
+	wg        holster.WaitGroup
+	ctx       context.Context
+	conf      ElectionConfig
+	timeout   time.Duration
+	client    *etcd.Client
+	session   *Session
+	key       string
+	isLeader  int32
+	isRunning bool
+}
+
+type ElectionConfig struct {
+	// Optional function when provided is called every time leadership changes or an error occurs
+	EventObserver EventObserver
+	// The name of the election (IE: scout, blackbird, etc...)
+	Election string
+	// The name of this instance (IE: worker-n01, worker-n02, etc...)
+	Candidate string
+	// Seconds to wait before giving up the election if leader disconnected
+	TTL int64
+}
+
+// NewElection creates a new leader election and submits our candidate for leader.
+//
+//  client, _ := etcdutil.NewClient(nil)
+//
+//  // Start a leader election and attempt to become leader, only returns after
+//  // determining the current leader.
+//  election := etcdutil.NewElection(client, etcdutil.ElectionConfig{
+//      Election: "presidental",
+//      Candidate: "donald",
+//		EventObserver: func(e etcdutil.Event) {
+//		  	fmt.Printf("Leader Data: %t\n", e.LeaderData)
+//			if e.IsLeader {
+//				// Do thing as leader
+//			}
+//		},
+//      TTL: 5,
+//  })
+//
+//	// Returns true if we are leader (thread safe)
+//	if election.IsLeader() {
+//		// Do periodic thing
+//	}
+//
+//  // Concede the election if leader and cancel our candidacy
+//  // for the election.
+//  election.Close()
+//
+func NewElection(ctx context.Context, client *etcd.Client, conf ElectionConfig) (*Election, error) {
+	if conf.Election == "" {
+		return nil, errors.New("ElectionConfig.Election can not be empty")
+	}
+
+	log = logrus.WithField("category", "election")
+
+	// Default to short 5 second leadership TTL
+	holster.SetDefault(&conf.TTL, int64(5))
+	conf.Election = path.Join("/elections", conf.Election)
+
+	// Use the hostname if no candidate name provided
+	if host, err := os.Hostname(); err == nil {
+		holster.SetDefault(&conf.Candidate, host)
+	}
+
+	e := &Election{
+		backOff:   holster.NewBackOff(time.Millisecond*500, time.Duration(conf.TTL)*time.Second, 2),
+		timeout:   time.Duration(conf.TTL) * time.Second,
+		observers: make(map[string]EventObserver),
+		client:    client,
+		conf:      conf,
+	}
+
+	e.ctx, e.cancel = context.WithCancel(context.Background())
+
+	// If an observer was provided
+	if conf.EventObserver != nil {
+		e.observers["conf"] = conf.EventObserver
+	}
+
+	var err error
+	ready := make(chan struct{})
+	// Register ourselves as an observer for the initial election, then remove before returning
+	e.observers["init"] = func(event Event) {
+		// If we get an error while waiting on the election results, pass that back to the caller
+		if event.Err != nil {
+			err = event.Err
+		}
+		delete(e.observers, "init")
+		close(ready)
+	}
+
+	// Create a new Session
+	if e.session, err = NewSession(e.client, SessionConfig{
+		Observer: e.onSessionChange,
+		TTL:      e.conf.TTL,
+	}); err != nil {
+		return nil, err
+	}
+
+	// Wait for results of leader election
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return e, err
+}
+
+func (e *Election) onSessionChange(leaseID etcd.LeaseID, err error) {
+	//log.Debugf("SessionChange: Lease ID: %v running: %t err: %v", leaseID, e.isRunning, err)
+
+	// If we lost our lease, concede the campaign and stop
+	if leaseID == NoLease {
+		// Avoid stopping twice
+		if !e.isRunning {
+			return
+		}
+		e.wg.Stop()
+		e.isRunning = false
+		atomic.StoreInt32(&e.isLeader, 0)
+		if err != nil {
+			e.onErr(err, "lease error")
+		}
+		return
+	}
+
+	if e.isRunning {
+		return
+	}
+
+	e.isRunning = true
+
+	e.wg.Until(func(done chan struct{}) bool {
+		var err error
+		var rev int64
+
+		rev, err = e.registerCampaign(leaseID)
+		if err != nil {
+			e.onErr(err, "during campaign registration")
+			select {
+			case <-time.After(e.backOff.Next()):
+				return true
+			case <-done:
+				e.isRunning = false
+				return false
+			}
+		}
+
+		if err := e.watchCampaign(rev); err != nil {
+			e.onErr(err, "during campaign watch")
+			select {
+			case <-time.After(e.backOff.Next()):
+				return true
+			case <-done:
+			}
+
+			// If delete takes longer than our TTL then lease is expired
+			// and we are no longer leader anyway.
+			ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+			// Withdraw our candidacy since an error occurred
+			if err := e.withDrawCampaign(ctx); err != nil {
+				e.onErr(err, "")
+			}
+			cancel()
+			return true
+		}
+		e.backOff.Reset()
+		return false
+	})
+}
+
+func (e *Election) withDrawCampaign(ctx context.Context) error {
+	defer func() {
+		atomic.StoreInt32(&e.isLeader, 0)
+	}()
+
+	_, err := e.client.Delete(ctx, e.key)
+	if err != nil {
+		return errors.Wrapf(err, "while withdrawing campaign '%s'", e.key)
+	}
+	return nil
+}
+
+func (e *Election) registerCampaign(id etcd.LeaseID) (revision int64, err error) {
+	// Create an entry under the election prefix with our lease ID as the key name
+	e.key = fmt.Sprintf("%s%x", e.conf.Election, id)
+	txn := e.client.Txn(e.ctx).If(etcd.Compare(etcd.CreateRevision(e.key), "=", 0))
+	txn = txn.Then(etcd.OpPut(e.key, e.conf.Candidate, etcd.WithLease(id)))
+	txn = txn.Else(etcd.OpGet(e.key))
+	resp, err := txn.Commit()
+	if err != nil {
+		return 0, err
+	}
+	revision = resp.Header.Revision
+
+	// This shouldn't happen, our session should always tell us if we disconnected and
+	// etcd should have provided us with a unique lease id. If it does happen then
+	// we should write our candidate name as the value and assume ownership
+	if !resp.Succeeded {
+		kv := resp.Responses[0].GetResponseRange().Kvs[0]
+		revision = kv.CreateRevision
+		if string(kv.Value) != e.conf.Candidate {
+			if _, err = e.client.Put(e.ctx, e.key, e.conf.Candidate); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return revision, nil
+}
+
+// getLeader returns a KV pair for the current leader
+func (e *Election) getLeader(ctx context.Context) (*mvccpb.KeyValue, error) {
+	// The leader is the first entry under the election prefix
+	resp, err := e.client.Get(ctx, e.conf.Election, etcd.WithFirstCreate()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+	return resp.Kvs[0], nil
+}
+
+// watchCampaign monitors the status of the campaign and notifying any
+// changes in leadership to the observer.
+func (e *Election) watchCampaign(rev int64) error {
+	var watchChan etcd.WatchChan
+	ready := make(chan struct{})
+
+	// Get the current leader of this election
+	leaderKV, err := e.getLeader(e.ctx)
+	if err != nil {
+		return errors.Wrap(err, "while querying for current leader")
+	}
+	if leaderKV == nil {
+		return errors.Wrap(err, "found no leader when watch began")
+	}
+
+	watcher := etcd.NewWatcher(e.client)
+
+	// We do this because watcher does not reliably return when errors occur on connect
+	// or when cancelled (See https://github.com/etcd-io/etcd/pull/10020)
+	go func() {
+		watchChan = watcher.Watch(etcd.WithRequireLeader(e.ctx), e.conf.Election,
+			etcd.WithRev(int64(rev+1)), etcd.WithPrefix())
+		close(ready)
+	}()
+
+	select {
+	case <-ready:
+	case <-e.ctx.Done():
+		return errors.Wrap(e.ctx.Err(), "while waiting for etcd watch to start")
+	}
+
+	// Notify the observers of the current leader
+	e.onLeaderChange(leaderKV)
+
+	e.wg.Until(func(done chan struct{}) bool {
+		select {
+		case resp := <-watchChan:
+			if resp.Canceled {
+				e.onFatalErr(errors.New("remote server cancelled watch"), "during campaign watch")
+				return false
+			}
+			if err := resp.Err(); err != nil {
+				e.onFatalErr(err, "during campaign watch, remote server returned err")
+				return false
+			}
+
+			// Watch for changes in leadership
+			for _, event := range resp.Events {
+				if event.Type == etcd.EventTypeDelete || event.Type == etcd.EventTypePut {
+					// If the key is for our current leader
+					if bytes.Compare(event.Kv.Key, leaderKV.Key) == 0 {
+						// Check our leadership status
+						resp, err := e.getLeader(e.ctx)
+						if err != nil {
+							e.onFatalErr(err, "while querying for new leader")
+							return false
+						}
+
+						// If we have no leader
+						if resp == nil {
+							e.onFatalErr(err, "After etcd event no leader was found, restarting election")
+							return false
+						}
+						// Notify if leadership has changed
+						if bytes.Compare(resp.Key, leaderKV.Key) != 0 {
+							leaderKV = resp
+							e.onLeaderChange(leaderKV)
+						}
+					}
+				}
+			}
+		case <-done:
+			watcher.Close()
+			// If withdraw takes longer than our TTL then lease is expired
+			// and we are no longer leader anyway.
+			ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+
+			// Withdraw our candidacy because of shutdown
+			if err := e.withDrawCampaign(ctx); err != nil {
+				e.onErr(err, "")
+			}
+			e.onLeaderChange(&mvccpb.KeyValue{})
+			cancel()
+			return false
+		}
+		return true
+	})
+	return nil
+}
+
+func (e *Election) onLeaderChange(kv *mvccpb.KeyValue) {
+	event := Event{}
+
+	if kv != nil {
+		if string(kv.Key) == e.key {
+			atomic.StoreInt32(&e.isLeader, 1)
+			event.IsLeader = true
+		} else {
+			atomic.StoreInt32(&e.isLeader, 0)
+		}
+		event.LeaderKey = string(kv.Key)
+		event.LeaderData = string(kv.Value)
+	} else {
+		event.IsDone = true
+	}
+
+	for _, v := range e.observers {
+		v(event)
+	}
+}
+
+// onErr reports errors the the observer
+func (e *Election) onErr(err error, msg string) {
+	atomic.StoreInt32(&e.isLeader, 0)
+
+	if msg != "" {
+		err = errors.Wrap(err, msg)
+	}
+
+	for _, v := range e.observers {
+		v(Event{Err: err})
+	}
+}
+
+// onFatalErr reports errors to the observer and resets the election and session
+func (e *Election) onFatalErr(err error, msg string) {
+	e.onErr(err, msg)
+	// We call this in a go routine to avoid blocking on `Stop()` calls
+	go e.session.Reset()
+}
+
+// Close cancels the election and concedes the election if we are leader
+func (e *Election) Close() {
+	e.session.Close()
+	e.wg.Wait()
+	// Emit the `Done:true` event
+	e.onLeaderChange(nil)
+}
+
+// IsLeader returns true if we are leader
+func (e *Election) IsLeader() bool {
+	return atomic.LoadInt32(&e.isLeader) == 1
+}
+
+// Concede concedes leadership if we are leader and restarts the campaign returns true.
+// if we are not leader do nothing and return false. If you want to concede leadership
+// and cancel the campaign call Close() instead.
+func (e *Election) Concede() (bool, error) {
+	isLeader := atomic.LoadInt32(&e.isLeader)
+	if isLeader == 0 {
+		return false, nil
+	}
+	oldCampaignKey := e.key
+	e.session.Reset()
+
+	// Ensure there are no lingering candiates
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(e.conf.TTL)*time.Second)
+	cancel()
+
+	_, err := e.client.Delete(ctx, oldCampaignKey)
+	if err != nil {
+		return true, errors.Wrapf(err, "while cleaning up campaign '%s'", oldCampaignKey)
+	}
+
+	return true, nil
+}
+
+type AlwaysLeaderMock struct{}
+
+func (s *AlwaysLeaderMock) IsLeader() bool         { return true }
+func (s *AlwaysLeaderMock) Concede() (bool, error) { return true, nil }
+func (s *AlwaysLeaderMock) Close()                 {}

--- a/v3/etcdutil/election_test.go
+++ b/v3/etcdutil/election_test.go
@@ -1,0 +1,86 @@
+package etcdutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mailgun/holster/v3/etcdutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestElection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	election, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
+		EventObserver: func(e etcdutil.Event) {
+			if e.Err != nil {
+				t.Fatal(e.Err.Error())
+			}
+		},
+		Election:  "/my-election",
+		Candidate: "me",
+	})
+	require.Nil(t, err)
+
+	assert.Equal(t, true, election.IsLeader())
+	election.Close()
+	assert.Equal(t, false, election.IsLeader())
+}
+
+func TestTwoCampaigns(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	logrus.SetLevel(logrus.DebugLevel)
+
+	c1, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
+		EventObserver: func(e etcdutil.Event) {
+			if e.Err != nil {
+				t.Fatal(e.Err.Error())
+			}
+		},
+		Election:  "/my-election",
+		Candidate: "c1",
+	})
+	require.Nil(t, err)
+
+	c2Chan := make(chan etcdutil.Event, 5)
+	c2, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
+		EventObserver: func(e etcdutil.Event) {
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			c2Chan <- e
+		},
+		Election:  "/my-election",
+		Candidate: "c2",
+	})
+	require.Nil(t, err)
+
+	assert.Equal(t, true, c1.IsLeader())
+	assert.Equal(t, false, c2.IsLeader())
+
+	// Cancel first candidate
+	c1.Close()
+	assert.Equal(t, false, c1.IsLeader())
+
+	// Second campaign should become leader
+	e := <-c2Chan
+	assert.Equal(t, false, e.IsLeader)
+	e = <-c2Chan
+	assert.Equal(t, true, e.IsLeader)
+	assert.Equal(t, false, e.IsDone)
+
+	c2.Close()
+	e = <-c2Chan
+	assert.Equal(t, false, e.IsLeader)
+	assert.Equal(t, false, e.IsDone)
+
+	e = <-c2Chan
+	assert.Equal(t, false, e.IsLeader)
+	assert.Equal(t, true, e.IsDone)
+}

--- a/v3/etcdutil/session.go
+++ b/v3/etcdutil/session.go
@@ -1,0 +1,156 @@
+package etcdutil
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster"
+	"github.com/pkg/errors"
+)
+
+const NoLease = etcd.LeaseID(-1)
+
+type SessionObserver func(etcd.LeaseID, error)
+
+type Session struct {
+	keepAlive     <-chan *etcd.LeaseKeepAliveResponse
+	lease         *etcd.LeaseGrantResponse
+	backOff       *holster.BackOffCounter
+	wg            holster.WaitGroup
+	ctx           context.Context
+	cancel        context.CancelFunc
+	conf          SessionConfig
+	client        *etcd.Client
+	timeout       time.Duration
+	lastKeepAlive time.Time
+	isRunning     int32
+}
+
+type SessionConfig struct {
+	TTL      int64
+	Observer SessionObserver
+}
+
+// NewSession creates a lease and monitors lease keep alive's for connectivity.
+// Once a lease ID is granted SessionConfig.Observer is called with the granted lease.
+// If connectivity is lost with etcd SessionConfig.Observer is called again with -1 (NoLease)
+// as the lease ID. The Session will continue to try to gain another lease, once a new lease
+// is gained SessionConfig.Observer is called again with the new lease id.
+func NewSession(c *etcd.Client, conf SessionConfig) (*Session, error) {
+	holster.SetDefault(&conf.TTL, int64(30))
+
+	if conf.Observer == nil {
+		return nil, errors.New("provided observer function cannot be nil")
+	}
+
+	if c == nil {
+		return nil, errors.New("provided etcd client cannot be nil")
+	}
+
+	s := Session{
+		timeout: time.Second * time.Duration(conf.TTL),
+		backOff: holster.NewBackOff(time.Millisecond*500, time.Duration(conf.TTL)*time.Second, 2),
+		conf:    conf,
+		client:  c,
+	}
+
+	s.run()
+	return &s, nil
+}
+
+func (s *Session) run() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	ticker := time.NewTicker(s.timeout)
+	s.lastKeepAlive = time.Now()
+	atomic.StoreInt32(&s.isRunning, 1)
+
+	s.wg.Until(func(done chan struct{}) bool {
+		// If we have lost our keep alive, attempt to regain it
+		if s.keepAlive == nil {
+			if err := s.gainLease(s.ctx); err != nil {
+				s.conf.Observer(NoLease, errors.Wrap(err, "while attempting to gain new lease"))
+				select {
+				case <-time.After(s.backOff.Next()):
+					return true
+				case <-s.ctx.Done():
+					atomic.StoreInt32(&s.isRunning, 0)
+					return false
+				}
+				// TODO: Fix this in the library. Unreachable code
+				// return true
+			}
+		}
+		s.backOff.Reset()
+
+		select {
+		case _, ok := <-s.keepAlive:
+			if !ok {
+				//log.Warn("heartbeat lost")
+				s.keepAlive = nil
+			} else {
+				//log.Debug("heartbeat received")
+				s.lastKeepAlive = time.Now()
+			}
+		case <-ticker.C:
+			// Ensure we are getting heartbeats regularly
+			if time.Now().Sub(s.lastKeepAlive) > s.timeout {
+				//log.Warn("too long between heartbeats")
+				s.keepAlive = nil
+			}
+		case <-done:
+			s.keepAlive = nil
+			if s.lease != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+				if _, err := s.client.Revoke(ctx, s.lease.ID); err != nil {
+					s.conf.Observer(NoLease, errors.Wrap(err, "while revoking our lease during shutdown"))
+				}
+				cancel()
+			}
+			atomic.StoreInt32(&s.isRunning, 0)
+			return false
+		}
+
+		if s.keepAlive == nil {
+			s.conf.Observer(NoLease, nil)
+		}
+		return true
+	})
+}
+
+func (s *Session) Reset() {
+	if atomic.LoadInt32(&s.isRunning) != 1 {
+		return
+	}
+	s.Close()
+	s.run()
+}
+
+// Close terminates the session shutting down all network operations,
+// then SessionConfig.Observer is called with -1 (NoLease), only returns
+// once the session has closed successfully.
+func (s *Session) Close() {
+	if atomic.LoadInt32(&s.isRunning) != 1 {
+		return
+	}
+
+	s.cancel()
+	s.wg.Stop()
+	s.conf.Observer(NoLease, nil)
+}
+
+func (s *Session) gainLease(ctx context.Context) error {
+	var err error
+	s.lease, err = s.client.Grant(ctx, s.conf.TTL)
+	if err != nil {
+		return errors.Wrapf(err, "during grant lease")
+	}
+
+	s.keepAlive, err = s.client.KeepAlive(s.ctx, s.lease.ID)
+	if err != nil {
+		return err
+	}
+	s.conf.Observer(s.lease.ID, nil)
+	return nil
+}

--- a/v3/etcdutil/session_test.go
+++ b/v3/etcdutil/session_test.go
@@ -1,0 +1,120 @@
+package etcdutil_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Shopify/toxiproxy"
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster/v3/etcdutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var proxy *toxiproxy.Proxy
+var client *etcd.Client
+
+func TestMain(m *testing.M) {
+	proxy = toxiproxy.NewProxy()
+	proxy.Name = "etcd"
+	proxy.Upstream = "localhost:22379"
+	proxy.Listen = "0.0.0.0:2379"
+
+	if err := proxy.Start(); err != nil {
+		fmt.Printf("failed to start toxiproxy\n")
+		os.Exit(1)
+	}
+
+	var err error
+	client, err = etcdutil.NewClient(nil)
+	if err != nil {
+		fmt.Printf("failed to connect to etcd\n")
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	proxy.Stop()
+	client.Close()
+	os.Exit(code)
+}
+
+func TestNewSession(t *testing.T) {
+	leaseChan := make(chan etcd.LeaseID, 1)
+	getLease := func() etcd.LeaseID {
+		select {
+		case id := <-leaseChan:
+			return id
+		case <-time.After(time.Second * 5):
+			require.FailNow(t, "Timeout waiting for lease id")
+		}
+		return 0
+	}
+
+	session, err := etcdutil.NewSession(client, etcdutil.SessionConfig{
+		Observer: func(leaseId etcd.LeaseID, err error) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaseChan <- leaseId
+		},
+	})
+	require.Nil(t, err)
+	defer session.Close()
+
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	session.Close()
+
+	assert.Equal(t, etcdutil.NoLease, getLease())
+}
+
+func TestConnectivityLost(t *testing.T) {
+	leaseChan := make(chan etcd.LeaseID, 5)
+
+	getLease := func() etcd.LeaseID {
+		select {
+		case id := <-leaseChan:
+			return id
+		case <-time.After(time.Second * 5):
+			require.FailNow(t, "Timeout waiting for lease id")
+		}
+		return 0
+	}
+
+	logrus.SetLevel(logrus.DebugLevel)
+
+	session, err := etcdutil.NewSession(client, etcdutil.SessionConfig{
+		Observer: func(leaseId etcd.LeaseID, err error) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaseChan <- leaseId
+		},
+		TTL: 1,
+	})
+	require.Nil(t, err)
+	defer session.Close()
+
+	// Assert we get a valid lease id
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	// Interrupt the connection
+	proxy.Stop()
+
+	// Wait for session to realize the connection is gone
+	assert.Equal(t, etcdutil.NoLease, getLease())
+
+	// Restore the connection
+	require.Nil(t, proxy.Start())
+
+	// We should get a new lease
+	assert.NotEqual(t, etcdutil.NoLease, getLease())
+
+	session.Close()
+
+	// Should get a final NoLease after close
+	assert.Equal(t, etcdutil.NoLease, getLease())
+}

--- a/v3/setter/setter.go
+++ b/v3/setter/setter.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 Mailgun Technologies Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package setter
+
+import (
+	"reflect"
+)
+
+// If 'dest' is empty or of zero value, assign the default value.
+// This panics if the value is not a pointer or if value and
+// default value are not of the same type.
+//  var config struct {
+//		Verbose *bool
+//		Foo string
+//		Bar int
+//	}
+// 	holster.SetDefault(&config.Foo, "default")
+// 	holster.SetDefault(&config.Bar, 200)
+//
+// Supply additional default values and SetDefault will
+// choose the first default that is not of zero value
+//  holster.SetDefault(&config.Foo, os.Getenv("FOO"), "default")
+func SetDefault(dest interface{}, defaultValue ...interface{}) {
+	d := reflect.ValueOf(dest)
+	if d.Kind() != reflect.Ptr {
+		panic("holster.SetDefault: Expected first argument to be of type reflect.Ptr")
+	}
+	d = reflect.Indirect(d)
+	if IsZeroValue(d) {
+		// Use the first non zero default value we find
+		for _, value := range defaultValue {
+			v := reflect.ValueOf(value)
+			if !IsZeroValue(v) {
+				d.Set(reflect.ValueOf(value))
+				return
+			}
+		}
+	}
+}
+
+// Assign the first value that is not empty or of zero value.
+// This panics if the value is not a pointer or if value and
+// default value are not of the same type.
+//  var config struct {
+//		Verbose *bool
+//		Foo string
+//		Bar int
+//	}
+//
+//  loadFromFile(&config)
+//  argFoo = flag.String("foo", "", "foo via cli arg")
+//
+//  // Override the config file if 'foo' is provided via
+//  // the cli or defined in the environment.
+// 	holster.SetOverride(&config.Foo, *argFoo, os.Env("FOO"))
+//
+// Supply additional values and SetOverride() will
+// choose the first value that is not of zero value. If all
+// values are empty or zero the 'dest' will remain unchanged.
+func SetOverride(dest interface{}, values ...interface{}) {
+	d := reflect.ValueOf(dest)
+	if d.Kind() != reflect.Ptr {
+		panic("holster.SetOverride: Expected first argument to be of type reflect.Ptr")
+	}
+	d = reflect.Indirect(d)
+	// Use the first non zero value value we find
+	for _, value := range values {
+		v := reflect.ValueOf(value)
+		if !IsZeroValue(v) {
+			d.Set(reflect.ValueOf(value))
+			return
+		}
+	}
+}
+
+// Returns true if 'value' is zero (the default golang value)
+//	var thingy string
+// 	holster.IsZero(thingy) == true
+func IsZero(value interface{}) bool {
+	return IsZeroValue(reflect.ValueOf(value))
+}
+
+// Returns true if 'value' is zero (the default golang value)
+//	var count int64
+// 	holster.IsZeroValue(reflect.ValueOf(count)) == true
+func IsZeroValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Array, reflect.String:
+		return value.Len() == 0
+	case reflect.Bool:
+		return !value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return value.Float() == 0
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	}
+	return false
+}

--- a/v3/setter/setter_test.go
+++ b/v3/setter/setter_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2017 Mailgun Technologies Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package setter_test
+
+import (
+	"github.com/mailgun/holster/v3/setter"
+	. "gopkg.in/check.v1"
+)
+
+type SetDefaultTestSuite struct{}
+
+var _ = Suite(&SetDefaultTestSuite{})
+
+func (s *SetDefaultTestSuite) SetUpSuite(c *C) {
+}
+
+func (s *SetDefaultTestSuite) TestIfEmpty(c *C) {
+	var conf struct {
+		Foo string
+		Bar int
+	}
+	c.Assert(conf.Foo, Equals, "")
+	c.Assert(conf.Bar, Equals, 0)
+
+	// Should apply the default values
+	setter.SetDefault(&conf.Foo, "default")
+	setter.SetDefault(&conf.Bar, 200)
+
+	c.Assert(conf.Foo, Equals, "default")
+	c.Assert(conf.Bar, Equals, 200)
+
+	conf.Foo = "thrawn"
+	conf.Bar = 500
+
+	// Should NOT apply the default values
+	setter.SetDefault(&conf.Foo, "default")
+	setter.SetDefault(&conf.Bar, 200)
+
+	c.Assert(conf.Foo, Equals, "thrawn")
+	c.Assert(conf.Bar, Equals, 500)
+}
+
+func (s *SetDefaultTestSuite) TestIfDefaultPrecedence(c *C) {
+	var conf struct {
+		Foo string
+		Bar string
+	}
+	c.Assert(conf.Foo, Equals, "")
+	c.Assert(conf.Bar, Equals, "")
+
+	// Should use the final default value
+	envValue := ""
+	setter.SetDefault(&conf.Foo, envValue, "default")
+	c.Assert(conf.Foo, Equals, "default")
+
+	// Should use envValue
+	envValue = "bar"
+	setter.SetDefault(&conf.Bar, envValue, "default")
+	c.Assert(conf.Bar, Equals, "bar")
+}
+
+func (s *SetDefaultTestSuite) TestIsEmpty(c *C) {
+	var count64 int64
+	var thing string
+
+	// Should return true
+	c.Assert(setter.IsZero(count64), Equals, true)
+	c.Assert(setter.IsZero(thing), Equals, true)
+
+	thing = "thrawn"
+	count64 = int64(1)
+	c.Assert(setter.IsZero(count64), Equals, false)
+	c.Assert(setter.IsZero(thing), Equals, false)
+}
+
+func (s *SetDefaultTestSuite) TestIfEmptyTypePanic(c *C) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.Assert(r, Equals, "reflect.Set: value of type int is not assignable to type string")
+		}
+	}()
+
+	var thing string
+	// Should panic
+	setter.SetDefault(&thing, 1)
+	c.Fatalf("Should have caught panic")
+}
+
+func (s *SetDefaultTestSuite) TestIfEmptyNonPtrPanic(c *C) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.Assert(r, Equals, "setter.SetDefault: Expected first argument to be of type reflect.Ptr")
+		}
+	}()
+
+	var thing string
+	// Should panic
+	setter.SetDefault(thing, "thrawn")
+	c.Fatalf("Should have caught panic")
+}


### PR DESCRIPTION
We added go.mod to the repo but since it is on version v3.x.x that was not enough to claim go mod support. We have to go all the way through and adopt [Semantic Import Versioning](https://github.com/golang/go/wiki/Modules#semantic-import-versioning). Hence `v3` is introduced here. I deliberately put only a handful of packages that mailgun/querator depends on (directly and indirectly) because some of the packages and functions here are not used anywhere and it felt like a good chance to clean things up. The selected packages are:
* `clock`
* `etcdutil`
* `setter` a new package created to contain `SetDefault` and `SetOverride` functions that used to be in `holster` package itself.
