### PR TITLE
PIP-598: Adopt go mod semantic import path (cont.)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
+	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/coreos/bbolt v1.3.2 // indirect
 	github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/ahmetb/go-linq v3.0.0+incompatible h1:qQkjjOXKrKOTy83X8OpRmnKflXKQIL/mC/gMVVDMhOA=
+github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht7vnCfnGlEpak/DVg5cY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/v3/callstack/callstack.go
+++ b/v3/callstack/callstack.go
@@ -1,0 +1,108 @@
+package callstack
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type FrameInfo struct {
+	CallStack string
+	Func      string
+	File      string
+	LineNo    int
+}
+
+func GetCallStack(frames errors.StackTrace) string {
+	var trace []string
+	for i := len(frames) - 1; i >= 0; i-- {
+		trace = append(trace, fmt.Sprintf("%v", frames[i]))
+	}
+	return strings.Join(trace, " ")
+}
+
+// GetLastFrame returns Caller information on the first frame in the stack trace.
+func GetLastFrame(frames errors.StackTrace) FrameInfo {
+	if len(frames) == 0 {
+		return FrameInfo{}
+	}
+	pc := uintptr(frames[0]) - 1
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return FrameInfo{Func: fmt.Sprintf("unknown func at %v", pc)}
+	}
+	filePath, lineNo := fn.FileLine(pc)
+	return FrameInfo{
+		CallStack: GetCallStack(frames),
+		Func:      FuncName(fn),
+		File:      filePath,
+		LineNo:    lineNo,
+	}
+}
+
+// FuncName given a runtime function spec returns a short function name in
+// format `<package name>.<function name>` or if the function has a receiver
+// in format `<package name>.(<receiver>).<function name>`.
+func FuncName(fn *runtime.Func) string {
+	if fn == nil {
+		return ""
+	}
+	funcPath := fn.Name()
+	idx := strings.LastIndex(funcPath, "/")
+	if idx == -1 {
+		return funcPath
+	}
+	return funcPath[idx+1:]
+}
+
+type HasStackTrace interface {
+	StackTrace() errors.StackTrace
+}
+
+// CallStack represents a stack of program counters.
+type CallStack []uintptr
+
+func (cs *CallStack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *cs {
+				f := errors.Frame(pc)
+				_, _ = fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (cs *CallStack) StackTrace() errors.StackTrace {
+	f := make([]errors.Frame, len(*cs))
+	for i := 0; i < len(f); i++ {
+		f[i] = errors.Frame((*cs)[i])
+	}
+	return f
+}
+
+// New creates a new CallStack struct from current stack minus 'skip' number of frames.
+func New(skip int) *CallStack {
+	skip += 2
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	var st CallStack = pcs[0:n]
+	return &st
+}
+
+// GoRoutineID returns the current goroutine id.
+func GoRoutineID() uint64 {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	b = b[:bytes.IndexByte(b, ' ')]
+	n, _ := strconv.ParseUint(string(b), 10, 64)
+	return n
+}

--- a/v3/clock/README.md
+++ b/v3/clock/README.md
@@ -14,7 +14,7 @@ package foo
 import (
     "time"
 
-    "github.com/mailgun/holster/clock"
+    "github.com/mailgun/holster/v3/clock"
     . "gopkg.in/check.v1"
 )
 

--- a/v3/errors/README.md
+++ b/v3/errors/README.md
@@ -1,0 +1,197 @@
+# Errors
+Package is a fork of [https://github.com/pkg/errors](https://github.com/pkg/errors) with additional
+ functions for improving the relationship between structured logging and error handling in go.
+ 
+## Adding structured context to an error
+Wraps the original error while providing structured context data
+```go
+_, err := ioutil.ReadFile(fileName)
+if err != nil {
+        return errors.WithContext{"file": fileName}.Wrap(err, "read failed")
+}
+```
+
+## Retrieving the structured context
+Using `errors.WithContext{}` stores the provided context for later retrieval by upstream code or structured logging
+systems
+```go
+// Pass to logrus as structured logging
+logrus.WithFields(errors.ToLogrus(err)).Error("open file error")
+```
+Stack information on the source of the error is also included
+```go
+context := errors.ToMap(err)
+context == map[string]interface{}{
+      "file": "my-file.txt",
+      "go-func": "loadFile()",
+      "go-line": 146,
+      "go-file": "with_context_example.go"
+}
+```
+
+## Conforms to the `Causer` interface
+Errors wrapped with `errors.WithContext{}` are compatible with errors wrapped by `github.com/pkg/errors`
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+## Proper Usage
+The context wrapped by `errors.WithContext{}` is not intended to be used to by code to decide how an error should be 
+handled. It is a convenience where the failure is well known, but the context is dynamic. In other words, you know the
+database returned an unrecoverable query error, but creating a new error type with the details of each query
+error is overkill **ErrorFetchPage{}, ErrorFetchAll{}, ErrorFetchAuthor{}, etc...**
+
+As an example
+```go
+func (r *Repository) FetchAuthor(isbn string) (Author, error) {
+    // Returns ErrorNotFound{} if not exist
+    book, err := r.fetchBook(isbn)
+    if err != nil {
+        return nil, errors.WithContext{"isbn": isbn}.Wrap(err, "while fetching book")
+    }
+    // Returns ErrorNotFound{} if not exist
+    author, err := r.fetchAuthorByBook(book)
+    if err != nil {
+        return nil, errors.WithContext{"book": book}.Wrap(err, "while fetching author")
+    }
+    return author, nil
+}
+```
+
+You should continue to create and inspect error types
+```go
+type ErrorAuthorNotFound struct {}
+
+func isNotFound(err error) {
+    _, ok := err.(*ErrorAuthorNotFound)
+    return ok
+}
+
+func main() {
+    r := Repository{}
+    author, err := r.FetchAuthor("isbn-213f-23422f52356")
+    if err != nil {
+        // Fetch the original Cause() and determine if the error is recoverable
+        if isNotFound(error.Cause(err)) {
+                author, err := r.AddBook("isbn-213f-23422f52356", "charles", "darwin")
+        }
+        if err != nil {
+                logrus.WithFields(errors.ToLogrus(err)).Errorf("while fetching author - %s", err)
+                os.Exit(1)
+        }
+    }
+    fmt.Printf("Author %+v\n", author)
+}
+```
+
+## Context for concrete error types
+If the error implements the `errors.HasContext` interface the context can be retrieved
+```go
+context, ok := err.(errors.HasContext)
+if ok {
+    fmt.Println(context.Context())
+}
+```
+
+This makes it easy for error types to provide their context information.
+ ```go
+type ErrorBookNotFound struct {
+    ISBN string
+}
+// Implements the `HasContext` interface
+func (e *ErrorBookNotFound) func Context() map[string]interface{} {
+    return map[string]interface{}{
+        "isbn": e.ISBN,
+    }
+ }
+```
+Now we can create the error and logrus knows how to retrieve the context
+ 
+```go
+func (* Repository) FetchBook(isbn string) (*Book, error) {
+    var book Book
+    err := r.db.Query("SELECT * FROM books WHERE isbn = ?").One(&book)
+    if err != nil {
+        return nil, ErrorBookNotFound{ISBN: isbn}
+    }
+}
+
+func main() {
+    r := Repository{}
+    book, err := r.FetchBook("isbn-213f-23422f52356")
+    if err != nil {
+        logrus.WithFields(errors.ToLogrus(err)).Errorf("while fetching book - %s", err)
+        os.Exit(1)
+    }
+    fmt.Printf("Book %+v\n", book)
+}
+```
+
+
+## A Complete example
+The following is a complete example using
+http://github.com/mailgun/logrus-hooks/kafkahook to marshal the context into ES
+fields.
+
+```go
+package main
+
+import (
+    "log"
+    "io/ioutil"
+
+    "github.com/mailgun/holster/v3/errors"
+    "github.com/mailgun/logrus-hooks/kafkahook"
+    "github.com/sirupsen/logrus"
+)
+
+func OpenWithError(fileName string) error {
+    _, err := ioutil.ReadFile(fileName)
+    if err != nil {
+            // pass the filename up via the error context
+            return errors.WithContext{
+                "file": fileName,
+            }.Wrap(err, "read failed")
+    }
+    return nil
+}
+
+func main() {
+    // Init the kafka hook logger
+    hook, err := kafkahook.New(kafkahook.Config{
+        Endpoints: []string{"kafka-n01", "kafka-n02"},
+        Topic:     "udplog",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Add the hook to logrus
+    logrus.AddHook(hook)
+
+    // Create an error and log it
+    if err := OpenWithError("/tmp/non-existant.file"); err != nil {
+        // This log line will show up in ES with the additional fields
+        //
+        // excText: "read failed"
+        // excValue: "read failed: open /tmp/non-existant.file: no such file or directory"
+        // excType: "*errors.WithContext"
+        // filename: "/src/to/main.go"
+        // funcName: "main()"
+        // lineno: 25
+        // context.file: "/tmp/non-existant.file"
+        // context.domain.id: "some-id"
+        // context.foo: "bar"
+        logrus.WithFields(logrus.Fields{
+            "domain.id": "some-id",
+            "foo": "bar",
+            "err": err,
+        }).Error("log messge")
+    }
+}
+```

--- a/v3/errors/bench_test.go
+++ b/v3/errors/bench_test.go
@@ -1,0 +1,57 @@
+// +build go1.7
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	stderrors "errors"
+)
+
+func noErrors(at, depth int) error {
+	if at >= depth {
+		return stderrors.New("no error")
+	}
+	return noErrors(at+1, depth)
+}
+
+func yesErrors(at, depth int) error {
+	if at >= depth {
+		return New("ye error")
+	}
+	return yesErrors(at+1, depth)
+}
+
+func BenchmarkErrors(b *testing.B) {
+	type run struct {
+		stack int
+		std   bool
+	}
+	runs := []run{
+		{10, false},
+		{10, true},
+		{100, false},
+		{100, true},
+		{1000, false},
+		{1000, true},
+	}
+	for _, r := range runs {
+		part := "pkg/errors"
+		if r.std {
+			part = "errors"
+		}
+		name := fmt.Sprintf("%s-stack-%d", part, r.stack)
+		b.Run(name, func(b *testing.B) {
+			f := yesErrors
+			if r.std {
+				f = noErrors
+			}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = f(0, r.stack)
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/v3/errors/context_map.go
+++ b/v3/errors/context_map.go
@@ -1,0 +1,79 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/mailgun/holster/v3/callstack"
+	pkg "github.com/pkg/errors"
+)
+
+// Implements the `error` `causer` and `Contexter` interfaces
+type withContext struct {
+	context WithContext
+	msg     string
+	cause   error
+	stack   *callstack.CallStack
+}
+
+func (c *withContext) Cause() error {
+	return c.cause
+}
+
+func (c *withContext) Error() string {
+	if len(c.msg) == 0 {
+		return c.cause.Error()
+	}
+	return c.msg + ": " + c.cause.Error()
+}
+
+func (c *withContext) StackTrace() pkg.StackTrace {
+	if child, ok := c.cause.(callstack.HasStackTrace); ok {
+		return child.StackTrace()
+	}
+	return c.stack.StackTrace()
+}
+
+func (c *withContext) Context() map[string]interface{} {
+	result := make(map[string]interface{}, len(c.context))
+	for key, value := range c.context {
+		result[key] = value
+	}
+
+	// downstream context values have precedence as they are closer to the cause
+	if child, ok := c.cause.(HasContext); ok {
+		downstream := child.Context()
+		if downstream == nil {
+			return result
+		}
+
+		for key, value := range downstream {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func (c *withContext) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		_, _ = fmt.Fprintf(s, "%s: %+v (%s)", c.msg, c.Cause(), c.FormatFields())
+	case 's', 'q':
+		_, _ = io.WriteString(s, c.Error())
+	}
+}
+
+func (c *withContext) FormatFields() string {
+	var buf bytes.Buffer
+	var count int
+
+	for key, value := range c.context {
+		if count > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(fmt.Sprintf("%+v=%+v", key, value))
+		count++
+	}
+	return buf.String()
+}

--- a/v3/errors/errors.go
+++ b/v3/errors/errors.go
@@ -1,0 +1,389 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/mailgun/holster/v3/callstack"
+	pkg "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:       message,
+		CallStack: callstack.New(1),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:       fmt.Sprintf(format, args...),
+		CallStack: callstack.New(1),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*callstack.CallStack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = io.WriteString(s, f.msg)
+			f.CallStack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = io.WriteString(s, f.msg)
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callstack.New(1),
+	}
+}
+
+type withStack struct {
+	error
+	*callstack.CallStack
+}
+
+func (w *withStack) Cause() error { return w.error }
+func (w *withStack) Context() map[string]interface{} {
+	if child, ok := w.error.(HasContext); ok {
+		return child.Context()
+	}
+	return nil
+}
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v", w.Cause())
+			w.CallStack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = io.WriteString(s, w.Error())
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callstack.New(1),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callstack.New(1),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v\n", w.Cause())
+			_, _ = io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		_, _ = io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}
+
+// Returns the context for the underlying error as map[string]interface{}
+// If no context is available returns nil
+func ToMap(err error) map[string]interface{} {
+	var result map[string]interface{}
+
+	// Add context if provided
+	child, ok := err.(HasContext)
+	if !ok {
+		return result
+	}
+
+	if result == nil {
+		return child.Context()
+	}
+
+	// Append the context map to our results
+	for key, value := range child.Context() {
+		result[key] = value
+	}
+	return result
+}
+
+// Returns the context and stacktrace information for the underlying error as logrus.Fields{}
+// returns empty logrus.Fields{} if err has no context or no stacktrace
+//
+// 	logrus.WithFields(errors.ToLogrus(err)).WithField("tid", 1).Error(err)
+//
+func ToLogrus(err error) logrus.Fields {
+	result := logrus.Fields{
+		"excValue": err.Error(),
+		"excType":  fmt.Sprintf("%T", Cause(err)),
+		"excText":  fmt.Sprintf("%+v", err),
+	}
+
+	// Add the stack info if provided
+	if cast, ok := err.(callstack.HasStackTrace); ok {
+		trace := cast.StackTrace()
+		caller := callstack.GetLastFrame(trace)
+		result["excFuncName"] = caller.Func
+		result["excLineno"] = caller.LineNo
+		result["excFileName"] = caller.File
+	}
+
+	// Add context if provided
+	child, ok := err.(HasContext)
+	if !ok {
+		return result
+	}
+
+	// Append the context map to our results
+	for key, value := range child.Context() {
+		result[key] = value
+	}
+	return result
+}
+
+type CauseError struct {
+	stack *callstack.CallStack
+	error error
+}
+
+// Creates a new error that becomes the cause even if 'err' is a wrapped error
+// but preserves the Context() and StackTrace() information. This allows the user
+// to create a concrete error type without losing context
+//
+//	// Our new concrete type encapsulates CauseError
+// 	type RetryError struct {
+//		errors.CauseError
+//	}
+//
+//	func NewRetryError(err error) *RetryError {
+//		return &RetryError{errors.NewCauseError(err, 1)}
+//	}
+//
+//	// Returns true if the error is of type RetryError
+//	func IsRetryError(err error) bool {
+//		err = errors.Cause(err)
+//		_, ok := err.(*RetryError)
+//		return ok
+//	}
+//
+func NewCauseError(err error, depth ...int) *CauseError {
+	var stk *callstack.CallStack
+	if len(depth) > 0 {
+		stk = callstack.New(1 + depth[0])
+	} else {
+		stk = callstack.New(1)
+	}
+	return &CauseError{
+		stack: stk,
+		error: err,
+	}
+}
+
+func (e *CauseError) Error() string { return e.error.Error() }
+func (e *CauseError) Context() map[string]interface{} {
+	if child, ok := e.error.(HasContext); ok {
+		return child.Context()
+	}
+	return nil
+}
+func (e *CauseError) StackTrace() pkg.StackTrace {
+	if child, ok := e.error.(callstack.HasStackTrace); ok {
+		return child.StackTrace()
+	}
+	return e.stack.StackTrace()
+}
+
+// TODO: Add Format() support

--- a/v3/errors/errors_test.go
+++ b/v3/errors/errors_test.go
@@ -1,0 +1,225 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		err  string
+		want error
+	}{
+		{"", fmt.Errorf("")},
+		{"foo", fmt.Errorf("foo")},
+		{"foo", New("foo")},
+		{"string with format specifiers: %v", errors.New("string with format specifiers: %v")},
+	}
+
+	for _, tt := range tests {
+		got := New(tt.err)
+		if got.Error() != tt.want.Error() {
+			t.Errorf("New.Error(): got: %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestWrapNil(t *testing.T) {
+	got := Wrap(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrap(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrap(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrap(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrap(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+type nilError struct{}
+
+func (nilError) Error() string { return "nil error" }
+
+func TestCause(t *testing.T) {
+	x := New("error")
+	tests := []struct {
+		err  error
+		want error
+	}{{
+		// nil error is nil
+		err:  nil,
+		want: nil,
+	}, {
+		// explicit nil error is nil
+		err:  (error)(nil),
+		want: nil,
+	}, {
+		// typed nil is nil
+		err:  (*nilError)(nil),
+		want: (*nilError)(nil),
+	}, {
+		// uncaused error is unaffected
+		err:  io.EOF,
+		want: io.EOF,
+	}, {
+		// caused error returns cause
+		err:  Wrap(io.EOF, "ignored"),
+		want: io.EOF,
+	}, {
+		err:  x, // return from errors.New
+		want: x,
+	}, {
+		WithMessage(nil, "whoops"),
+		nil,
+	}, {
+		WithMessage(io.EOF, "whoops"),
+		io.EOF,
+	}, {
+		WithStack(nil),
+		nil,
+	}, {
+		WithStack(io.EOF),
+		io.EOF,
+	}}
+
+	for i, tt := range tests {
+		got := Cause(tt.err)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
+		}
+	}
+}
+
+func TestWrapfNil(t *testing.T) {
+	got := Wrapf(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrapf(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrapf(io.EOF, "read error without format specifiers"), "client error", "client error: read error without format specifiers: EOF"},
+		{Wrapf(io.EOF, "read error with %d format specifier", 1), "client error", "client error: read error with 1 format specifier: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrapf(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrapf(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{Errorf("read error without format specifiers"), "read error without format specifiers"},
+		{Errorf("read error with %d format specifier", 1), "read error with 1 format specifier"},
+	}
+
+	for _, tt := range tests {
+		got := tt.err.Error()
+		if got != tt.want {
+			t.Errorf("Errorf(%v): got: %q, want %q", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithStackNil(t *testing.T) {
+	got := WithStack(nil)
+	if got != nil {
+		t.Errorf("WithStack(nil): got %#v, expected nil", got)
+	}
+}
+
+func TestWithStack(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{io.EOF, "EOF"},
+		{WithStack(io.EOF), "EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithStack(tt.err).Error()
+		if got != tt.want {
+			t.Errorf("WithStack(%v): got: %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWithMessageNil(t *testing.T) {
+	got := WithMessage(nil, "no error")
+	if got != nil {
+		t.Errorf("WithMessage(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWithMessage(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{WithMessage(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := WithMessage(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("WithMessage(%v, %q): got: %q, want %q", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+// errors.New, etc values are not expected to be compared by value
+// but the change in errors#27 made them incomparable. Assert that
+// various kinds of errors have a functional equality operator, even
+// if the result of that equality is always false.
+func TestErrorEquality(t *testing.T) {
+	vals := []error{
+		nil,
+		io.EOF,
+		errors.New("EOF"),
+		New("EOF"),
+		Errorf("EOF"),
+		Wrap(io.EOF, "EOF"),
+		Wrapf(io.EOF, "EOF%d", 2),
+		WithMessage(nil, "whoops"),
+		WithMessage(io.EOF, "whoops"),
+		WithStack(io.EOF),
+		WithStack(nil),
+	}
+
+	for i := range vals {
+		for j := range vals {
+			_ = vals[i] == vals[j] // mustn't panic
+		}
+	}
+}

--- a/v3/errors/example_test.go
+++ b/v3/errors/example_test.go
@@ -1,0 +1,205 @@
+package errors_test
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func ExampleNew() {
+	err := errors.New("whoops")
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleNew_printf() {
+	err := errors.New("whoops")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleNew_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:17
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func ExampleWithMessage() {
+	cause := errors.New("whoops")
+	err := errors.WithMessage(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func ExampleWithStack() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleWithStack_printf() {
+	cause := errors.New("whoops")
+	err := errors.WithStack(cause)
+	fmt.Printf("%+v", err)
+
+	// Example Output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:55
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+	// github.com/pkg/errors_test.ExampleWithStack_printf
+	//         /home/fabstu/go/src/github.com/pkg/errors/example_test.go:56
+	// testing.runExample
+	//         /usr/lib/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /usr/lib/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /usr/lib/go/src/testing/testing.go:744
+	// main.main
+	//         github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /usr/lib/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /usr/lib/go/src/runtime/asm_amd64.s:2086
+}
+
+func ExampleWrap() {
+	cause := errors.New("whoops")
+	err := errors.Wrap(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func fn() error {
+	e1 := errors.New("error")
+	e2 := errors.Wrap(e1, "inner")
+	e3 := errors.Wrap(e2, "middle")
+	return errors.Wrap(e3, "outer")
+}
+
+func ExampleCause() {
+	err := fn()
+	fmt.Println(err)
+	fmt.Println(errors.Cause(err))
+
+	// Output: outer: middle: inner: error
+	// error
+}
+
+func ExampleWrap_extended() {
+	err := fn()
+	fmt.Printf("%+v\n", err)
+
+	// Example output:
+	// error
+	// github.com/pkg/errors_test.fn
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.ExampleCause_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:63
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:104
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+	// github.com/pkg/errors_test.fn
+	// 	  /home/dfc/src/github.com/pkg/errors/example_test.go:48: inner
+	// github.com/pkg/errors_test.fn
+	//        /home/dfc/src/github.com/pkg/errors/example_test.go:49: middle
+	// github.com/pkg/errors_test.fn
+	//      /home/dfc/src/github.com/pkg/errors/example_test.go:50: outer
+}
+
+func ExampleWrapf() {
+	cause := errors.New("whoops")
+	err := errors.Wrapf(cause, "oh noes #%d", 2)
+	fmt.Println(err)
+
+	// Output: oh noes #2: whoops
+}
+
+func ExampleErrorf_extended() {
+	err := errors.Errorf("whoops: %s", "foo")
+	fmt.Printf("%+v", err)
+
+	// Example output:
+	// whoops: foo
+	// github.com/pkg/errors_test.ExampleErrorf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:101
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:102
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+}
+
+func Example_stackTrace() {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	err, ok := errors.Cause(fn()).(stackTracer)
+	if !ok {
+		panic("oops, err does not implement stackTracer")
+	}
+
+	st := err.StackTrace()
+	fmt.Printf("%+v", st[0:2]) // top two frames
+
+	// Example output:
+	// github.com/pkg/errors_test.fn
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.Example_stackTrace
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127
+}
+
+func ExampleCause_printf() {
+	err := errors.Wrap(func() error {
+		return func() error {
+			return errors.Errorf("hello %s", fmt.Sprintf("world"))
+		}()
+	}(), "failed")
+
+	fmt.Printf("%v", err)
+
+	// Output: failed: hello world
+}

--- a/v3/errors/format_test.go
+++ b/v3/errors/format_test.go
@@ -1,0 +1,535 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestFormatNew(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		New("error"),
+		"%s",
+		"error",
+	}, {
+		New("error"),
+		"%v",
+		"error",
+	}, {
+		New("error"),
+		"%+v",
+		"error\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatNew\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:26",
+	}, {
+		New("error"),
+		"%q",
+		`"error"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatErrorf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Errorf("%s", "error"),
+		"%s",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%v",
+		"error",
+	}, {
+		Errorf("%s", "error"),
+		"%+v",
+		"error\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatErrorf\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:56",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrap(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrap(New("error"), "error2"),
+		"%s",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%v",
+		"error2: error",
+	}, {
+		Wrap(New("error"), "error2"),
+		"%+v",
+		"error\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatWrap\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:82",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%s",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%v",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%+v",
+		"EOF\n" +
+			"error\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatWrap\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:96",
+	}, {
+		Wrap(Wrap(io.EOF, "error1"), "error2"),
+		"%+v",
+		"EOF\n" +
+			"error1\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatWrap\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:103\n",
+	}, {
+		Wrap(New("error with space"), "context"),
+		"%q",
+		`"context: error with space"`,
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrapf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
+		Wrapf(io.EOF, "error%d", 2),
+		"%s",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%v",
+		"error2: EOF",
+	}, {
+		Wrapf(io.EOF, "error%d", 2),
+		"%+v",
+		"EOF\n" +
+			"error2\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:134",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%s",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%v",
+		"error2: error",
+	}, {
+		Wrapf(New("error"), "error%d", 2),
+		"%+v",
+		"error\n" +
+			"github.com/mailgun/holster/v3/errors.TestFormatWrapf\n" +
+			"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:149",
+	}}
+
+	for i, tt := range tests {
+		testFormatRegexp(t, i, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWithStack(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithStack(io.EOF),
+		"%s",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%v",
+		[]string{"EOF"},
+	}, {
+		WithStack(io.EOF),
+		"%+v",
+		[]string{"EOF",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:175"},
+	}, {
+		WithStack(New("error")),
+		"%s",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%v",
+		[]string{"error"},
+	}, {
+		WithStack(New("error")),
+		"%+v",
+		[]string{"error",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:189",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:189"},
+	}, {
+		WithStack(WithStack(io.EOF)),
+		"%+v",
+		[]string{"EOF",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:197",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:197"},
+	}, {
+		WithStack(WithStack(Wrapf(io.EOF, "message"))),
+		"%+v",
+		[]string{"EOF",
+			"message",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:205",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:205",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:205"},
+	}, {
+		WithStack(Errorf("error%d", 1)),
+		"%+v",
+		[]string{"error1",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:216",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithStack\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:216"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatWithMessage(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   []string
+	}{{
+		WithMessage(New("error"), "error2"),
+		"%s",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%v",
+		[]string{"error2: error"},
+	}, {
+		WithMessage(New("error"), "error2"),
+		"%+v",
+		[]string{
+			"error",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:244",
+			"error2"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%s",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%v",
+		[]string{"addition1: EOF"},
+	}, {
+		WithMessage(io.EOF, "addition1"),
+		"%+v",
+		[]string{"EOF", "addition1"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%v",
+		[]string{"addition2: addition1: EOF"},
+	}, {
+		WithMessage(WithMessage(io.EOF, "addition1"), "addition2"),
+		"%+v",
+		[]string{"EOF", "addition1", "addition2"},
+	}, {
+		Wrap(WithMessage(io.EOF, "error1"), "error2"),
+		"%+v",
+		[]string{"EOF", "error1", "error2",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:272"},
+	}, {
+		WithMessage(Errorf("error%d", 1), "error2"),
+		"%+v",
+		[]string{"error1",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:278",
+			"error2"},
+	}, {
+		WithMessage(WithStack(io.EOF), "error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:285",
+			"error"},
+	}, {
+		WithMessage(Wrap(WithStack(io.EOF), "inside-error"), "outside-error"),
+		"%+v",
+		[]string{
+			"EOF",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:293",
+			"inside-error",
+			"github.com/mailgun/holster/v3/errors.TestFormatWithMessage\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:293",
+			"outside-error"},
+	}}
+
+	for i, tt := range tests {
+		testFormatCompleteCompare(t, i, tt.error, tt.format, tt.want, true)
+	}
+}
+
+func TestFormatGeneric(t *testing.T) {
+	starts := []struct {
+		err  error
+		want []string
+	}{
+		{New("new-error"), []string{
+			"new-error",
+			"github.com/mailgun/holster/v3/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:315"},
+		}, {Errorf("errorf-error"), []string{
+			"errorf-error",
+			"github.com/mailgun/holster/v3/errors.TestFormatGeneric\n" +
+				"\t.+/github.com/mailgun/holster/v3/errors/format_test.go:319"},
+		}, {errors.New("errors-new-error"), []string{
+			"errors-new-error"},
+		},
+	}
+
+	wrappers := []wrapper{
+		{
+			func(err error) error { return WithMessage(err, "with-message") },
+			[]string{"with-message"},
+		}, {
+			func(err error) error { return WithStack(err) },
+			[]string{
+				"github.com/mailgun/holster/v3/errors.(func·002|TestFormatGeneric.func2)\n\t" +
+					".+/github.com/mailgun/holster/v3/errors/format_test.go:333",
+			},
+		}, {
+			func(err error) error { return Wrap(err, "wrap-error") },
+			[]string{
+				"wrap-error",
+				"github.com/mailgun/holster/v3/errors.(func·003|TestFormatGeneric.func3)\n\t" +
+					".+/github.com/mailgun/holster/v3/errors/format_test.go:339",
+			},
+		}, {
+			func(err error) error { return Wrapf(err, "wrapf-error%d", 1) },
+			[]string{
+				"wrapf-error1",
+				"github.com/mailgun/holster/v3/errors.(func·004|TestFormatGeneric.func4)\n\t" +
+					".+/github.com/mailgun/holster/v3/errors/format_test.go:346",
+			},
+		},
+	}
+
+	for s := range starts {
+		err := starts[s].err
+		want := starts[s].want
+		testFormatCompleteCompare(t, s, err, "%+v", want, false)
+		testGenericRecursive(t, err, want, wrappers, 3)
+	}
+}
+
+func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	got := fmt.Sprintf(format, arg)
+	gotLines := strings.SplitN(got, "\n", -1)
+	wantLines := strings.SplitN(want, "\n", -1)
+
+	if len(wantLines) > len(gotLines) {
+		t.Errorf("test %d: wantLines(%d) > gotLines(%d):\n got: %q\nwant: %q", n+1, len(wantLines), len(gotLines), got, want)
+		return
+	}
+
+	for i, w := range wantLines {
+		match, err := regexp.MatchString(w, gotLines[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("test %d: line %d: fmt.Sprintf(%q, err):\n got: %q\nwant: %q", n+1, i+1, format, got, want)
+		}
+	}
+}
+
+var stackLineR = regexp.MustCompile(`\.`)
+
+// parseBlocks parses input into a slice, where:
+//  - incase entry contains a newline, its a stacktrace
+//  - incase entry contains no newline, its a solo line.
+//
+// Detecting stack boundaries only works incase the WithStack-calls are
+// to be found on the same line, thats why it is optionally here.
+//
+// Example use:
+//
+// for _, e := range blocks {
+//   if strings.ContainsAny(e, "\n") {
+//     // Match as stack
+//   } else {
+//     // Match as line
+//   }
+// }
+//
+func parseBlocks(input string, detectStackboundaries bool) ([]string, error) {
+	var blocks []string
+
+	stack := ""
+	wasStack := false
+	lines := map[string]bool{} // already found lines
+
+	for _, l := range strings.Split(input, "\n") {
+		isStackLine := stackLineR.MatchString(l)
+
+		switch {
+		case !isStackLine && wasStack:
+			blocks = append(blocks, stack, l)
+			stack = ""
+			lines = map[string]bool{}
+		case isStackLine:
+			if wasStack {
+				// Detecting two stacks after another, possible cause lines match in
+				// our tests due to WithStack(WithStack(io.EOF)) on same line.
+				if detectStackboundaries {
+					if lines[l] {
+						if len(stack) == 0 {
+							return nil, errors.New("len of block must not be zero here")
+						}
+
+						blocks = append(blocks, stack)
+						stack = l
+						lines = map[string]bool{l: true}
+						continue
+					}
+				}
+
+				stack = stack + "\n" + l
+			} else {
+				stack = l
+			}
+			lines[l] = true
+		case !isStackLine && !wasStack:
+			blocks = append(blocks, l)
+		default:
+			return nil, errors.New("must not happen")
+		}
+
+		wasStack = isStackLine
+	}
+
+	// Use up stack
+	if stack != "" {
+		blocks = append(blocks, stack)
+	}
+	return blocks, nil
+}
+
+func testFormatCompleteCompare(t *testing.T, n int, arg interface{}, format string, want []string, detectStackBoundaries bool) {
+	gotStr := fmt.Sprintf(format, arg)
+
+	got, err := parseBlocks(gotStr, detectStackBoundaries)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("test %d: fmt.Sprintf(%s, err) -> wrong number of blocks: got(%d) want(%d)\n got: %s\nwant: %s\ngotStr: %q",
+			n+1, format, len(got), len(want), prettyBlocks(got), prettyBlocks(want), gotStr)
+	}
+
+	for i := range got {
+		if strings.ContainsAny(want[i], "\n") {
+			// Match as stack
+			match, err := regexp.MatchString(want[i], got[i])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !match {
+				t.Fatalf("test %d: block %d: fmt.Sprintf(%q, err):\ngot:\n%q\nwant:\n%q\nall-got:\n%s\nall-want:\n%s\n",
+					n+1, i+1, format, got[i], want[i], prettyBlocks(got), prettyBlocks(want))
+			}
+		} else {
+			// Match as message
+			if got[i] != want[i] {
+				t.Fatalf("test %d: fmt.Sprintf(%s, err) at block %d got != want:\n got: %q\nwant: %q", n+1, format, i+1, got[i], want[i])
+			}
+		}
+	}
+}
+
+type wrapper struct {
+	wrap func(err error) error
+	want []string
+}
+
+func prettyBlocks(blocks []string, prefix ...string) string {
+	var out []string
+
+	for _, b := range blocks {
+		out = append(out, fmt.Sprintf("%v", b))
+	}
+
+	return "   " + strings.Join(out, "\n   ")
+}
+
+func testGenericRecursive(t *testing.T, beforeErr error, beforeWant []string, list []wrapper, maxDepth int) {
+	if len(beforeWant) == 0 {
+		panic("beforeWant must not be empty")
+	}
+	for _, w := range list {
+		if len(w.want) == 0 {
+			panic("want must not be empty")
+		}
+
+		err := w.wrap(beforeErr)
+
+		// Copy required cause append(beforeWant, ..) modified beforeWant subtly.
+		beforeCopy := make([]string, len(beforeWant))
+		copy(beforeCopy, beforeWant)
+
+		beforeWant := beforeCopy
+		last := len(beforeWant) - 1
+		var want []string
+
+		// Merge two stacks behind each other.
+		if strings.ContainsAny(beforeWant[last], "\n") && strings.ContainsAny(w.want[0], "\n") {
+			want = append(beforeWant[:last], append([]string{beforeWant[last] + "((?s).*)" + w.want[0]}, w.want[1:]...)...)
+		} else {
+			want = append(beforeWant, w.want...)
+		}
+
+		testFormatCompleteCompare(t, maxDepth, err, "%+v", want, false)
+		if maxDepth > 0 {
+			testGenericRecursive(t, err, want, list, maxDepth-1)
+		}
+	}
+}

--- a/v3/errors/with_context.go
+++ b/v3/errors/with_context.go
@@ -1,0 +1,68 @@
+package errors
+
+import (
+	"fmt"
+
+	"github.com/mailgun/holster/v3/callstack"
+)
+
+// Implement this interface to pass along unstructured context to the logger
+type HasContext interface {
+	Context() map[string]interface{}
+}
+
+// True if the interface has the format method (from fmt package)
+type HasFormat interface {
+	Format(st fmt.State, verb rune)
+}
+
+// Creates errors that conform to the `HasContext` interface
+type WithContext map[string]interface{}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func (c WithContext) Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withContext{
+		stack:   callstack.New(1),
+		context: c,
+		cause:   err,
+		msg:     fmt.Sprintf(format, args...),
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func (c WithContext) Wrap(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	return &withContext{
+		stack:   callstack.New(1),
+		context: c,
+		cause:   err,
+		msg:     msg,
+	}
+}
+
+func (c WithContext) Error(msg string) error {
+	return &withContext{
+		stack:   callstack.New(1),
+		context: c,
+		cause:   fmt.Errorf(msg),
+		msg:     "",
+	}
+}
+
+func (c WithContext) Errorf(format string, args ...interface{}) error {
+	return &withContext{
+		stack:   callstack.New(1),
+		context: c,
+		cause:   fmt.Errorf(format, args...),
+		msg:     "",
+	}
+}

--- a/v3/errors/with_context_test.go
+++ b/v3/errors/with_context_test.go
@@ -1,0 +1,79 @@
+package errors_test
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	linq "github.com/ahmetb/go-linq"
+	"github.com/mailgun/holster/v3/callstack"
+	"github.com/mailgun/holster/v3/errors"
+	. "gopkg.in/check.v1"
+)
+
+type TestError struct {
+	Msg string
+}
+
+func (err *TestError) Error() string {
+	return err.Msg
+}
+
+func TestErrors(t *testing.T) { TestingT(t) }
+
+type WithContextTestSuite struct{}
+
+var _ = Suite(&WithContextTestSuite{})
+
+func (s *WithContextTestSuite) SetUpSuite(c *C) {
+}
+
+func (s *WithContextTestSuite) TestContext(c *C) {
+	// Wrap an error with context
+	err := &TestError{Msg: "query error"}
+	wrap := errors.WithContext{"key1": "value1"}.Wrap(err, "message")
+	c.Assert(wrap, NotNil)
+
+	// Extract as normal map
+	errMap := errors.ToMap(wrap)
+	c.Assert(errMap, NotNil)
+	c.Assert(errMap["key1"], Equals, "value1")
+
+	// Also implements the causer interface
+	err = errors.Cause(wrap).(*TestError)
+	c.Assert(err.Msg, Equals, "query error")
+
+	out := fmt.Sprintf("%s", wrap)
+	c.Assert(out, Equals, "message: query error")
+
+	// Should output the message, fields and trace
+	out = fmt.Sprintf("%+v", wrap)
+	c.Assert(strings.Contains(out, `message: query error (`), Equals, true)
+	c.Assert(strings.Contains(out, `key1=value1`), Equals, true)
+}
+
+func (s *WithContextTestSuite) TestWithStack(c *C) {
+	err := errors.WithStack(io.EOF)
+
+	var files []string
+	var funcs []string
+	if cast, ok := err.(callstack.HasStackTrace); ok {
+		for _, frame := range cast.StackTrace() {
+			files = append(files, fmt.Sprintf("%s", frame))
+			funcs = append(funcs, fmt.Sprintf("%n", frame))
+		}
+	}
+	c.Assert(linq.From(files).Contains("with_context_test.go"), Equals, true)
+	c.Assert(linq.From(funcs).Contains("(*WithContextTestSuite).TestWithStack"), Equals, true)
+}
+
+func (s *WithContextTestSuite) TestWrapfNil(c *C) {
+	got := errors.WithContext{"some": "context"}.Wrapf(nil, "no error")
+	c.Assert(got, IsNil)
+}
+
+func (s *WithContextTestSuite) TestWrapNil(c *C) {
+	got := errors.WithContext{"some": "context"}.Wrap(nil, "no error")
+	c.Assert(got, IsNil)
+}

--- a/v3/etcdutil/README.md
+++ b/v3/etcdutil/README.md
@@ -9,8 +9,7 @@ the service currently has it and will withdraw the candidate from the election.
 ```go
 
 import (
-    "github.com/mailgun/holster"
-    "github.com/mailgun/holster/etcdutil"
+    "github.com/mailgun/holster/v3/etcdutil"
 )
 
 func main() {
@@ -81,7 +80,7 @@ import (
     "os"
     "fmt"
 
-    "github.com/mailgun/holster/etcdutil"
+    "github.com/mailgun/holster/v3/etcdutil"
 )
 
 func main() {
@@ -118,7 +117,7 @@ import (
     "os"
     "fmt"
 
-    "github.com/mailgun/holster/etcdutil"
+    "github.com/mailgun/holster/v3/etcdutil"
 )
 
 func main() {

--- a/v3/etcdutil/backoff.go
+++ b/v3/etcdutil/backoff.go
@@ -1,20 +1,18 @@
-package holster
+package etcdutil
 
 import (
 	"math"
 	"time"
 )
 
-var backoff = NewBackOff(time.Millisecond*300, time.Second*30, 2)
-
-type BackOffCounter struct {
+type backOffCounter struct {
 	min, max time.Duration
 	factor   float64
 	attempt  int
 }
 
-func NewBackOff(min, max time.Duration, factor float64) *BackOffCounter {
-	return &BackOffCounter{
+func newBackOffCounter(min, max time.Duration, factor float64) *backOffCounter {
+	return &backOffCounter{
 		factor: factor,
 		min:    min,
 		max:    max,
@@ -24,19 +22,19 @@ func NewBackOff(min, max time.Duration, factor float64) *BackOffCounter {
 // Next returns the next back off duration based on the number of
 // times Next() was called. Each call to next returns the next factor
 // of back off. Call Reset() to reset the back off attempts to zero.
-func (b *BackOffCounter) Next() time.Duration {
+func (b *backOffCounter) Next() time.Duration {
 	d := b.BackOff(b.attempt)
 	b.attempt++
 	return d
 }
 
 // Reset sets the back off attempt counter to zero
-func (b *BackOffCounter) Reset() {
+func (b *backOffCounter) Reset() {
 	b.attempt = 0
 }
 
 // BackOff calculates the back depending on the attempts provided
-func (b *BackOffCounter) BackOff(attempt int) time.Duration {
+func (b *backOffCounter) BackOff(attempt int) time.Duration {
 	d := time.Duration(float64(b.min) * math.Pow(b.factor, float64(attempt)))
 	if d > b.max {
 		return b.max
@@ -45,11 +43,4 @@ func (b *BackOffCounter) BackOff(attempt int) time.Duration {
 		return b.min
 	}
 	return d
-}
-
-// BackOff is a convenience function which returns a back off duration
-// with a default 300 millisecond minimum and a 30 second maximum with
-// a factor of 2 for each attempt.
-func BackOff(attempt int) time.Duration {
-	return backoff.BackOff(attempt)
 }

--- a/v3/etcdutil/waitgroup.go
+++ b/v3/etcdutil/waitgroup.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2017 Mailgun Technologies Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package etcdutil
+
+import "sync"
+
+type waitGroup struct {
+	wg    sync.WaitGroup
+	mutex sync.Mutex
+	errs  []error
+	done  chan struct{}
+}
+
+// Run a routine and collect errors if any
+func (wg *waitGroup) Run(callBack func(interface{}) error, data interface{}) {
+	wg.wg.Add(1)
+	go func() {
+		err := callBack(data)
+		if err == nil {
+			wg.wg.Done()
+			return
+		}
+		wg.mutex.Lock()
+		wg.errs = append(wg.errs, err)
+		wg.wg.Done()
+		wg.mutex.Unlock()
+	}()
+}
+
+// Execute a long running routine
+func (wg *waitGroup) Go(cb func()) {
+	wg.wg.Add(1)
+	go func() {
+		cb()
+		wg.wg.Done()
+	}()
+}
+
+// Run a goroutine in a loop continuously, if the callBack returns false the loop is broken.
+// `Until()` differs from `Loop()` in that if the `Stop()` is called on the WaitGroup
+// the `done` channel is closed. Implementations of the callBack function can listen
+// for the close to indicate a stop was requested.
+func (wg *waitGroup) Until(callBack func(done chan struct{}) bool) {
+	wg.mutex.Lock()
+	if wg.done == nil {
+		wg.done = make(chan struct{})
+	}
+	wg.mutex.Unlock()
+
+	wg.wg.Add(1)
+	go func() {
+		for {
+			if !callBack(wg.done) {
+				wg.wg.Done()
+				break
+			}
+		}
+	}()
+}
+
+// Stop closes the done channel passed into `Until()` calls and waits for
+// the `Until()` callBack to return false.
+func (wg *waitGroup) Stop() {
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+
+	if wg.done != nil {
+		close(wg.done)
+	}
+	wg.wg.Wait()
+	wg.done = nil
+}
+
+// Run a goroutine in a loop continuously, if the callBack returns false the loop is broken
+func (wg *waitGroup) Loop(callBack func() bool) {
+	wg.wg.Add(1)
+	go func() {
+		for {
+			if !callBack() {
+				wg.wg.Done()
+				break
+			}
+		}
+	}()
+}
+
+// Wait for all the routines to complete and return any errors collected
+func (wg *waitGroup) Wait() []error {
+	wg.wg.Wait()
+
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+
+	if len(wg.errs) == 0 {
+		return nil
+	}
+	return wg.errs
+}

--- a/v3/etcdutil/waitgroup_test.go
+++ b/v3/etcdutil/waitgroup_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2017 Mailgun Technologies Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package etcdutil
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	linq "github.com/ahmetb/go-linq"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/suite"
+)
+
+type WaitGroupTestSuite struct {
+	suite.Suite
+}
+
+func TestWaitGroup(t *testing.T) {
+	suite.Run(t, new(WaitGroupTestSuite))
+}
+
+func (s *WaitGroupTestSuite) TestRun() {
+	var wg waitGroup
+
+	items := []error{
+		errors.New("Error 1"),
+		errors.New("Error 2"),
+	}
+
+	// Iterate over a thing and doing some long running thing for each
+	for _, item := range items {
+		wg.Run(func(item interface{}) error {
+			// Do some long running thing
+			time.Sleep(time.Nanosecond * 50)
+			// Return an error for testing
+			return item.(error)
+		}, item)
+	}
+
+	errs := wg.Wait()
+	s.NotNil(errs)
+	s.Equal(2, len(errs))
+	s.Equal(true, linq.From(errs).Contains(items[0]))
+	s.Equal(true, linq.From(errs).Contains(items[1]))
+}
+
+func (s *WaitGroupTestSuite) TestGo() {
+	var wg waitGroup
+	result := make(chan struct{})
+
+	wg.Go(func() {
+		// Do some long running thing
+		time.Sleep(time.Nanosecond * 500)
+		result <- struct{}{}
+	})
+
+	wg.Go(func() {
+		// Do some long running thing
+		time.Sleep(time.Nanosecond * 50)
+		result <- struct{}{}
+	})
+
+OUT:
+	for i := 0; i < 2; {
+		select {
+		case <-result:
+			i++
+		case <-time.After(time.Second):
+			s.Fail("waited to long for Go() to run")
+			break OUT
+		}
+	}
+
+	errs := wg.Wait()
+	s.Nil(errs)
+}
+
+func (s *WaitGroupTestSuite) TestLoop() {
+	pipe := make(chan int32, 0)
+	var wg waitGroup
+	var count int32
+
+	wg.Loop(func() bool {
+		select {
+		case inc, ok := <-pipe:
+			if !ok {
+				return false
+			}
+			atomic.AddInt32(&count, inc)
+		}
+		return true
+	})
+
+	// Feed the loop some numbers and close the pipe
+	pipe <- 1
+	pipe <- 5
+	pipe <- 10
+	close(pipe)
+
+	// Wait for the routine to end
+	// no error collection when using Loop()
+	errs := wg.Wait()
+	s.Nil(errs)
+	s.Equal(int32(16), count)
+}
+
+func (s *WaitGroupTestSuite) TestUntil() {
+	pipe := make(chan int32, 0)
+	var wg waitGroup
+	var count int32
+
+	wg.Until(func(done chan struct{}) bool {
+		select {
+		case inc := <-pipe:
+			atomic.AddInt32(&count, inc)
+		case <-done:
+			return false
+		}
+		return true
+	})
+
+	wg.Until(func(done chan struct{}) bool {
+		select {
+		case inc := <-pipe:
+			atomic.AddInt32(&count, inc)
+		case <-done:
+			return false
+		}
+		return true
+	})
+
+	// Feed the loop some numbers and close the pipe
+	pipe <- 1
+	pipe <- 5
+	pipe <- 10
+
+	// Wait for the routine to end
+	wg.Stop()
+	s.Equal(int32(16), count)
+}


### PR DESCRIPTION
Followup to #50, turns out packages `errors` and `callstack` are also needed. And there were a few references to the root `holster` packages left from `v3` packages.