### PR TITLE
implement a function "slice.ContainsStringIgnoreCase"

### DIFF
--- a/slice/string.go
+++ b/slice/string.go
@@ -1,5 +1,7 @@
 package slice
 
+import "strings"
+
 // ContainsString checks if a given slice of strings contains the provided string.
 // If a modifier func is provided, it is called with the slice item before the comparation.
 //      haystack := []string{"one", "Two", "Three"}
@@ -12,6 +14,22 @@ func ContainsString(s string, slice []string, modifier func(s string) string) bo
 			return true
 		}
 		if modifier != nil && modifier(item) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsStringEqualFold checks if a given slice of strings contains the provided string
+// as ignore the cases.
+//
+//  haystack := []string{"aa", "bb", "Cc"}
+//	if slice.ContainsStringEqualFold(haystack, "cC") {
+//		// Do thing
+// 	}
+func ContainsStringEqualFold(s string, slice []string) bool {
+	for _, item := range slice {
+		if strings.EqualFold(item, s) {
 			return true
 		}
 	}

--- a/slice/string_test.go
+++ b/slice/string_test.go
@@ -1,0 +1,102 @@
+package slice_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mailgun/holster/slice"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainsString(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		str      string
+		modifier func(string) string
+		want     bool
+	}{
+		{
+			name:     "Slice contains a specific string",
+			slice:    []string{"aa", "bb", "CC"},
+			modifier: strings.ToLower,
+			str:      "CC",
+			want:     true,
+		},
+		{
+			name:  "Slice contains a string, but it is with upper cases and modifier is nil",
+			slice: []string{"aa", "bb", "CC"},
+			str:   "cc",
+			want:  false,
+		},
+		{
+			name:     "Slice contains a string with upper cases and modifier ToLower is provided",
+			slice:    []string{"AA", "bb", "cc"},
+			modifier: strings.ToLower,
+			str:      "aa",
+			want:     true,
+		},
+		{
+			name:  "Slice does not contains string",
+			slice: []string{"AA", "bb", "cc"},
+			str:   "notExist",
+			want:  false,
+		},
+		{
+			name:  "Empty slice",
+			slice: []string{},
+			str:   "notExist",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := slice.ContainsString(tt.str, tt.slice, tt.modifier)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestContainsStringIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		slice []string
+		str   string
+		want  bool
+	}{
+		{
+			name:  "Slice contains a specific string, but with different upper case",
+			slice: []string{"aa", "bb", "cC"},
+			str:   "Cc",
+			want:  true,
+		},
+		{
+			name:  "Slice contains a string, but it is with upper case",
+			slice: []string{"aa", "bb", "CC"},
+			str:   "cc",
+			want:  true,
+		},
+		{
+			name:  "Slice contains a string, but it is with lower cases",
+			slice: []string{"aa", "bb", "cc"},
+			str:   "AA",
+			want:  true,
+		},
+		{
+			name:  "Slice does not contains string",
+			slice: []string{"AA", "bb", "cc"},
+			str:   "notExist",
+			want:  false,
+		},
+		{
+			name:  "Empty slice",
+			slice: []string{},
+			str:   "notExist",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		got := slice.ContainsStringEqualFold(tt.str, tt.slice)
+		assert.Equal(t, tt.want, got)
+	}
+}


### PR DESCRIPTION
This function can be usefull and more easy to use instead of "slice.ContainsString"
becasue is not necesary the user to provide modifier function. Also if the user
wants to compare a string to the items of a slice with case insensitive, he
can't rely to pass a modifier to "slice.ContainsString(...)", becasue modifier
is applied only to the element of the slice ("aA" and "Aa" will be
always not equal).