### PR TITLE
PIP-683: Add NewElectionAsync

### DIFF
--- a/v3/etcdutil/election.go
+++ b/v3/etcdutil/election.go
@@ -132,13 +132,10 @@ func NewElection(ctx context.Context, client *etcd.Client, conf ElectionConfig) 
 		close(ready)
 	}
 	e.session = &Session{
-		timeout: e.ttl,
-		backOff: e.backOff,
-		conf: SessionConfig{
-			Observer: e.onSessionChange,
-			TTL:      conf.TTL,
-		},
-		client: client,
+		observer: e.onSessionChange,
+		ttl:      e.ttl,
+		backOff:  e.backOff,
+		client:   client,
 	}
 	e.session.start()
 

--- a/v3/etcdutil/election.go
+++ b/v3/etcdutil/election.go
@@ -168,7 +168,7 @@ func NewElectionAsync(client *etcd.Client, conf ElectionConfig) *Election {
 	e.session = &Session{
 		observer: e.onSessionChange,
 		ttl:      e.ttl,
-		backOff:  e.backOff,
+		backOff:  newBackOffCounter(500*time.Millisecond, ttlDuration, 2),
 		client:   client,
 	}
 	e.session.start()

--- a/v3/etcdutil/election.go
+++ b/v3/etcdutil/election.go
@@ -125,14 +125,14 @@ func NewElection(ctx context.Context, client *etcd.Client, conf ElectionConfig) 
 	return e, errors.WithStack(initialElectionErr)
 }
 
-// NewElection creates a new leader election and submits our candidate for
-// leader. It does not wait for a election to complete. The caller must provide
-// an election event observer to monitor events.
+// NewElectionAsync creates a new leader election and submits our candidate for
+// leader. It does not wait for the election to complete. The caller must
+// provide an election event observer to monitor the election outcome.
 //
 //  client, _ := etcdutil.NewClient(nil)
 //
 //  // Start a leader election and returns immediately.
-//  election := etcdutil.NewElection(client, etcdutil.ElectionConfig{
+//  election := etcdutil.NewElectionAsync(client, etcdutil.ElectionConfig{
 //      Election: "presidental",
 //      Candidate: "donald",
 //		EventObserver: func(e etcdutil.Event) {
@@ -425,7 +425,8 @@ func (e *Election) Close() {
 	e.onLeaderChange(nil)
 }
 
-// IsLeader returns true if we are leader
+// IsLeader returns true if we are leader. It only makes sense if the election
+// was created with NewElection that block until the initial election is over.
 func (e *Election) IsLeader() bool {
 	return atomic.LoadInt32(&e.isLeader) == 1
 }

--- a/v3/etcdutil/election_test.go
+++ b/v3/etcdutil/election_test.go
@@ -2,13 +2,20 @@ package etcdutil_test
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Shopify/toxiproxy"
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/mailgun/holster/v3/clock"
 	"github.com/mailgun/holster/v3/etcdutil"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestElection(t *testing.T) {
@@ -83,4 +90,228 @@ func TestTwoCampaigns(t *testing.T) {
 	e = <-c2Chan
 	assert.Equal(t, false, e.IsLeader)
 	assert.Equal(t, true, e.IsDone)
+}
+
+func TestElectionsSuite(t *testing.T) {
+	etcdCAPath := os.Getenv("ETCD3_CA")
+	if etcdCAPath != "" {
+		t.Skip("Tests featuring toxiproxy cannot deal with TLS")
+	}
+	suite.Run(t, new(ElectionsSuite))
+}
+
+type ElectionsSuite struct {
+	suite.Suite
+	toxiProxies    []*toxiproxy.Proxy
+	proxiedClients []*etcd.Client
+}
+
+func (s *ElectionsSuite) SetupTest() {
+	etcdEndpoint := os.Getenv("ETCD3_ENDPOINT")
+	if etcdEndpoint == "" {
+		etcdEndpoint = "127.0.0.1:2379"
+	}
+
+	s.toxiProxies = make([]*toxiproxy.Proxy, 2)
+	s.proxiedClients = make([]*etcd.Client, 2)
+	for i := range s.toxiProxies {
+		toxiProxy := toxiproxy.NewProxy()
+		toxiProxy.Name = fmt.Sprintf("etcd_clt_%d", i)
+		toxiProxy.Upstream = etcdEndpoint
+		s.Require().Nil(toxiProxy.Start())
+		s.toxiProxies[i] = toxiProxy
+
+		var err error
+		// Make sure to access proxy via 127.0.0.1 otherwise TLS verification fails.
+		proxyEndpoint := toxiProxy.Listen
+		if strings.HasPrefix(proxyEndpoint, "[::]:") {
+			proxyEndpoint = "127.0.0.1:" + proxyEndpoint[5:]
+		}
+		s.proxiedClients[i], err = etcd.New(etcd.Config{
+			Endpoints:   []string{proxyEndpoint},
+			DialTimeout: 1 * clock.Second,
+		})
+		s.Require().Nil(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*clock.Second)
+	defer cancel()
+	_, err := s.proxiedClients[0].Delete(ctx, "/elections", etcd.WithPrefix())
+	s.Require().Nil(err)
+}
+
+func (s *ElectionsSuite) TearDownTest() {
+	for _, proxy := range s.toxiProxies {
+		proxy.Stop()
+	}
+	for _, etcdClt := range s.proxiedClients {
+		_ = etcdClt.Close()
+	}
+}
+
+// When the leader is stopped then another candidate is elected.
+func (s *ElectionsSuite) TestLeaderStops() {
+	campaign := "LeadershipTransferOnStop"
+	e0, ch0 := s.newElection(campaign, 0)
+	s.assertElectionWinner(ch0, 3*clock.Second)
+
+	e1, ch1 := s.newElection(campaign, 1)
+	defer e1.Close()
+	s.assertElectionLooser(ch1, 200*clock.Millisecond)
+
+	// When
+	e0.Close()
+
+	// Then
+	s.assertElectionWinner(ch1, 3*clock.Second)
+}
+
+// A candidate may never be elected.
+func (s *ElectionsSuite) TestNeverElected() {
+	campaign := "NeverElected"
+	e0, ch0 := s.newElection(campaign, 0)
+	defer e0.Close()
+	s.assertElectionWinner(ch0, 3*clock.Second)
+
+	e1, ch1 := s.newElection(campaign, 1)
+	s.assertElectionLooser(ch1, 200*clock.Millisecond)
+
+	// When
+	e1.Close()
+
+	// Then
+	s.assertElectionClosed(ch1, 200*clock.Millisecond)
+}
+
+// When the leader is loosing connection with etcd, then another candidate gets
+// promoted.
+func (s *ElectionsSuite) TestLeaderConnLost() {
+	campaign := "LeadershipLost"
+	e0, ch0 := s.newElection(campaign, 0)
+	defer e0.Close()
+	s.assertElectionWinner(ch0, 3*clock.Second)
+
+	e1, ch1 := s.newElection(campaign, 1)
+	defer e1.Close()
+	s.assertElectionLooser(ch1, 200*clock.Millisecond)
+
+	// When
+	s.toxiProxies[0].Stop()
+
+	// Then
+	s.assertElectionLooser(ch0, 5*clock.Second)
+	s.assertElectionWinner(ch1, 5*clock.Second)
+}
+
+// It is possible to stop a former leader while it is trying to reconnect with
+// Etcd.
+func (s *ElectionsSuite) TestLostLeaderStop() {
+	campaign := "LostLeaderStop"
+	e0, ch0 := s.newElection(campaign, 0)
+	s.assertElectionWinner(ch0, 3*clock.Second)
+
+	e1, ch1 := s.newElection(campaign, 1)
+	defer e1.Close()
+	s.assertElectionLooser(ch1, 200*clock.Millisecond)
+
+	// Given
+	s.toxiProxies[0].Stop()
+	clock.Sleep(2 * clock.Second)
+
+	// When
+	e0.Close()
+
+	// Then
+	s.assertElectionClosed(ch0, 3*clock.Second)
+}
+
+// FIXME: This test gets stuck on e0.Close().
+//// If Etcd is down on start the candidate keeps trying to connect.
+//func (s *ElectionsSuite) TestEtcdDownOnStart() {
+//	s.toxiProxies[0].Stop()
+//	campaign := "EtcdDownOnStart"
+//	e0, ch0 := s.newElection(campaign, 0)
+//
+//	// When
+//	_ = s.toxiProxies[0].Start()
+//
+//	// Then
+//	s.assertElectionWinner(ch0, 3*clock.Second)
+//	e0.Close()
+//}
+
+// If provided etcd endpoint candidate keeps trying to connect until it is
+// stopped.
+func (s *ElectionsSuite) TestBadEtcdEndpoint() {
+	s.toxiProxies[0].Stop()
+	campaign := "/BadEtcdEndpoint"
+	e0, ch0 := s.newElection(campaign, 0)
+
+	// When
+	e0.Close()
+
+	// Then
+	s.assertElectionClosed(ch0, 3*clock.Second)
+}
+
+func (s *ElectionsSuite) assertElectionWinner(ch chan bool, timeout clock.Duration) {
+	timeoutCh := clock.After(timeout)
+	for {
+		select {
+		case elected := <-ch:
+			if elected {
+				return
+			}
+		case <-timeoutCh:
+			s.Fail("Timeout waiting for election winning")
+		}
+	}
+}
+
+func (s *ElectionsSuite) assertElectionLooser(ch chan bool, timeout clock.Duration) {
+	timeoutCh := clock.After(timeout)
+	for {
+		select {
+		case elected := <-ch:
+			if !elected {
+				return
+			}
+		case <-timeoutCh:
+			s.Fail("Timeout waiting for election loss")
+		}
+	}
+}
+
+func (s *ElectionsSuite) assertElectionClosed(ch chan bool, timeout clock.Duration) {
+	timeoutCh := clock.After(timeout)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-timeoutCh:
+			s.Fail("Timeout waiting for election closed")
+		}
+	}
+}
+
+func (s *ElectionsSuite) newElection(campaign string, id int) (*etcdutil.Election, chan bool) {
+	electedCh := make(chan bool, 32)
+	candidate := fmt.Sprintf("candidate-%d", id)
+	electionCfg := etcdutil.ElectionConfig{
+		EventObserver: func(e etcdutil.ElectionEvent) {
+			logrus.Infof("%s got %#v", candidate, e)
+			if e.IsDone {
+				close(electedCh)
+				return
+			}
+			electedCh <- e.IsLeader
+		},
+		Election:  campaign,
+		Candidate: candidate,
+		TTL:       1,
+	}
+	e := etcdutil.NewElectionAsync(s.proxiedClients[id], electionCfg)
+	return e, electedCh
 }

--- a/v3/etcdutil/election_test.go
+++ b/v3/etcdutil/election_test.go
@@ -16,7 +16,7 @@ func TestElection(t *testing.T) {
 	defer cancel()
 
 	election, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
-		EventObserver: func(e etcdutil.Event) {
+		EventObserver: func(e etcdutil.ElectionEvent) {
 			if e.Err != nil {
 				t.Fatal(e.Err.Error())
 			}
@@ -38,7 +38,7 @@ func TestTwoCampaigns(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 
 	c1, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
-		EventObserver: func(e etcdutil.Event) {
+		EventObserver: func(e etcdutil.ElectionEvent) {
 			if e.Err != nil {
 				t.Fatal(e.Err.Error())
 			}
@@ -48,9 +48,9 @@ func TestTwoCampaigns(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	c2Chan := make(chan etcdutil.Event, 5)
+	c2Chan := make(chan etcdutil.ElectionEvent, 5)
 	c2, err := etcdutil.NewElection(ctx, client, etcdutil.ElectionConfig{
-		EventObserver: func(e etcdutil.Event) {
+		EventObserver: func(e etcdutil.ElectionEvent) {
 			if err != nil {
 				t.Fatal(err.Error())
 			}

--- a/v3/etcdutil/session.go
+++ b/v3/etcdutil/session.go
@@ -57,11 +57,11 @@ func NewSession(c *etcd.Client, conf SessionConfig) (*Session, error) {
 		client:  c,
 	}
 
-	s.run()
+	s.start()
 	return &s, nil
 }
 
-func (s *Session) run() {
+func (s *Session) start() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	ticker := time.NewTicker(s.timeout)
 	s.lastKeepAlive = time.Now()
@@ -125,7 +125,7 @@ func (s *Session) Reset() {
 		return
 	}
 	s.Close()
-	s.run()
+	s.start()
 }
 
 // Close terminates the session shutting down all network operations,

--- a/v3/etcdutil/session.go
+++ b/v3/etcdutil/session.go
@@ -22,9 +22,9 @@ type Session struct {
 	wg            syncutil.WaitGroup
 	ctx           context.Context
 	cancel        context.CancelFunc
-	conf          SessionConfig
+	observer      SessionObserver
 	client        *etcd.Client
-	timeout       time.Duration
+	ttl           time.Duration
 	lastKeepAlive time.Time
 	isRunning     int32
 }
@@ -50,11 +50,12 @@ func NewSession(c *etcd.Client, conf SessionConfig) (*Session, error) {
 		return nil, errors.New("provided etcd client cannot be nil")
 	}
 
+	ttlDuration := time.Second * time.Duration(conf.TTL)
 	s := Session{
-		timeout: time.Second * time.Duration(conf.TTL),
-		backOff: newBackOffCounter(time.Millisecond*500, time.Duration(conf.TTL)*time.Second, 2),
-		conf:    conf,
-		client:  c,
+		observer: conf.Observer,
+		ttl:      ttlDuration,
+		backOff:  newBackOffCounter(time.Millisecond*500, ttlDuration, 2),
+		client:   c,
 	}
 
 	s.start()
@@ -63,7 +64,7 @@ func NewSession(c *etcd.Client, conf SessionConfig) (*Session, error) {
 
 func (s *Session) start() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	ticker := time.NewTicker(s.timeout)
+	ticker := time.NewTicker(s.ttl)
 	s.lastKeepAlive = time.Now()
 	atomic.StoreInt32(&s.isRunning, 1)
 
@@ -71,7 +72,7 @@ func (s *Session) start() {
 		// If we have lost our keep alive, attempt to regain it
 		if s.keepAlive == nil {
 			if err := s.gainLease(s.ctx); err != nil {
-				s.conf.Observer(NoLease, errors.Wrap(err, "while attempting to gain new lease"))
+				s.observer(NoLease, errors.Wrap(err, "while attempting to gain new lease"))
 				select {
 				case <-time.After(s.backOff.Next()):
 					return true
@@ -96,16 +97,16 @@ func (s *Session) start() {
 			}
 		case <-ticker.C:
 			// Ensure we are getting heartbeats regularly
-			if time.Now().Sub(s.lastKeepAlive) > s.timeout {
+			if time.Now().Sub(s.lastKeepAlive) > s.ttl {
 				//log.Warn("too long between heartbeats")
 				s.keepAlive = nil
 			}
 		case <-done:
 			s.keepAlive = nil
 			if s.lease != nil {
-				ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+				ctx, cancel := context.WithTimeout(context.Background(), s.ttl)
 				if _, err := s.client.Revoke(ctx, s.lease.ID); err != nil {
-					s.conf.Observer(NoLease, errors.Wrap(err, "while revoking our lease during shutdown"))
+					s.observer(NoLease, errors.Wrap(err, "while revoking our lease during shutdown"))
 				}
 				cancel()
 			}
@@ -114,7 +115,7 @@ func (s *Session) start() {
 		}
 
 		if s.keepAlive == nil {
-			s.conf.Observer(NoLease, nil)
+			s.observer(NoLease, nil)
 		}
 		return true
 	})
@@ -138,12 +139,12 @@ func (s *Session) Close() {
 
 	s.cancel()
 	s.wg.Stop()
-	s.conf.Observer(NoLease, nil)
+	s.observer(NoLease, nil)
 }
 
 func (s *Session) gainLease(ctx context.Context) error {
 	var err error
-	s.lease, err = s.client.Grant(ctx, s.conf.TTL)
+	s.lease, err = s.client.Grant(ctx, int64(s.ttl/time.Second))
 	if err != nil {
 		return errors.Wrapf(err, "during grant lease")
 	}
@@ -152,6 +153,6 @@ func (s *Session) gainLease(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.conf.Observer(s.lease.ID, nil)
+	s.observer(s.lease.ID, nil)
 	return nil
 }

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -21,8 +21,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.10.0 // indirect
 	github.com/jonboulle/clockwork v0.1.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect


### PR DESCRIPTION
* Function `etcdutils.NewElectionAsync` returns very fast. Unlike `etcdutil.NewElection` it does not block until the initial election is over. Caller is supposed to provide an ElectionObserver to get notified when election is completed.
* Function `etcdutil.NewElection` was refactored in terms of `etcdutils.NewElectionAsync`;
* `conf` field was dropped from `Election` because some parameters (observer, timeout) were copied over to the struct anyway. Same thing was done with `Session`;
* `etcdutils.Event` was renamed to `etcdutils.ElectionEvent` but the original spelling was preserved as a deprecated type alias to make this change non-breaking;
* `timeout` field of `Election` was renamed to `ttl` because that is what it copied from in `ElectionConfig`. Same thing was done with `Session`;  
* `Session.run` was renamed to `start` because it actually spins up a goroutine that is running session and returns afterwards.