### PR TITLE
Added collections.LRUCache.Map()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ coverage.out
 mfput.log
 .idea/
 *.iml
+.DS_Store

--- a/collections/README.md
+++ b/collections/README.md
@@ -8,6 +8,8 @@ with the following
 * `Keys()` - Get a list of keys at this point in time
 * `Stats()` - Returns stats about the current state of the cache
 * `AddWithTTL()` - Adds a value to the cache with a expiration time
+* `Each()` - Concurrent non blocking access to each item in the cache
+* `Map()` - Effecient blocking modification to each item in the cache
 
 TTL is evaluated during calls to `.Get()` if the entry is past the requested TTL `.Get()`
 removes the entry from the cache counts a miss and returns not `ok`


### PR DESCRIPTION
## Purpose
To allow quick and efficient iteration of items in the cache such that modifications or evictions can be made within the scope of a single mutex lock.