### PR TITLE
Add lock to consul package

### DIFF
--- a/consul/lock.go
+++ b/consul/lock.go
@@ -1,0 +1,182 @@
+package consul
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/mailgun/holster/v3/setter"
+	"github.com/mailgun/holster/v3/syncutil"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type lock struct {
+	wg     syncutil.WaitGroup
+	cfg    *LockConfig
+	mutex  sync.Mutex
+	locked bool
+}
+
+type LockConfig struct {
+	Client      *api.Client
+	LockOptions *api.LockOptions
+	Log         *logrus.Entry
+	OnChange    func(bool)
+}
+
+// Lock attempts to get a lock then continues to keep the lock until told to stop
+type Lock interface {
+	PutValue(ctx context.Context, b []byte) error
+	Unlock(b []byte)
+	HasLock() bool
+}
+
+// SpawnLock spawns a goroutine to handle lock life cycle. Blocks until the lock is acquired,
+// or the context is cancelled. Returns a lock that holds the current state of the lock
+func SpawnLock(ctx context.Context, cfg *LockConfig) (*lock, error) {
+	l := &lock{
+		cfg: cfg,
+	}
+
+	setter.SetDefault(&l.cfg.Log, logrus.WithField("category", "consul-lock"))
+
+	// Start acquire lock loop
+	errCh := l.spawn(cfg.Client, cfg.LockOptions)
+
+	select {
+	case <-errCh:
+		return l, nil
+	case <-ctx.Done():
+		return nil, errors.Wrapf(ctx.Err(), "while waiting for initial lock on '%s'", cfg.LockOptions.Key)
+	}
+}
+
+func (l *lock) spawn(c *api.Client, opts *api.LockOptions) chan error {
+	l.cfg.Log = l.cfg.Log.WithField("lock-name", opts.Key)
+	errorCh := make(chan error)
+
+	l.wg.Until(func(done chan struct{}) bool {
+		running := true
+
+		// Case where we are looping trying to acquire the
+		// lock again but are asked to shutdown
+		select {
+		case <-done:
+			return false
+		default:
+		}
+
+		// Will only error on invalid config
+		lock, err := c.LockOpts(opts)
+		if err != nil {
+			errorCh <- errors.Wrap(err, "while creating lock")
+			return false
+		}
+
+		l.cfg.Log.Debug("acquiring lock")
+		lockCh, err := lock.Lock(nil)
+		if lockCh == nil {
+			if err == nil {
+				l.cfg.Log.Warn("timeout during lock acquisition; retrying")
+				goto RETRY
+			}
+			l.cfg.Log.WithError(err).Warn("lock acquisition failed; retrying")
+			time.Sleep(time.Second)
+			goto RETRY
+		}
+
+		select {
+		case <-lockCh:
+			l.cfg.Log.Warn("failed Lock acquisition; another instance trying to claim the lock?; retrying")
+			time.Sleep(time.Second)
+			goto RETRY
+		default:
+		}
+
+		l.setLocked(true)
+		// We have lock, notify if someone is listening
+		select {
+		case errorCh <- nil:
+		default:
+		}
+
+		// Wait for lock to be lost
+		select {
+		case <-lockCh:
+			l.cfg.Log.Warn("lock lost; retrying")
+			// Log lock was lost
+		case <-done:
+			running = false
+		}
+
+	RETRY:
+		// Release ownership of the lock and cancel the session
+		l.cfg.Log.Debug("releasing lock")
+		if err := lock.Unlock(); err != nil {
+			l.cfg.Log.WithError(err).Warn("while unlocking")
+		}
+		l.setLocked(false)
+
+		// If we are in shutdown
+		if !running {
+			if l.cfg.LockOptions.SessionOpts != nil &&
+				l.cfg.LockOptions.SessionOpts.Behavior == api.SessionBehaviorDelete {
+				if err := lock.Destroy(); err != nil {
+					l.cfg.Log.WithError(err).Warn("during lock destroy")
+				}
+			}
+		}
+		return running
+	})
+	return errorCh
+}
+
+func (l *lock) setLocked(s bool) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.cfg.Log.Debugf("Set Lock %t", s)
+	if l.cfg.OnChange != nil {
+		if l.locked != s {
+			l.cfg.OnChange(s)
+		}
+	}
+	l.locked = s
+}
+
+func (l *lock) HasLock() bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.locked
+}
+
+// PutValue stores the given byte slice into the value of the locked key in consul
+// returns error if the put failed, also updates the value that will be saved
+// when `Unlock()` is called.
+func (l *lock) PutValue(ctx context.Context, b []byte) error {
+	l.cfg.LockOptions.Value = b
+	_, err := l.cfg.Client.KV().Put(&api.KVPair{
+		Key:   l.cfg.LockOptions.Key,
+		Value: b,
+	}, new(api.WriteOptions).WithContext(ctx))
+	if err != nil {
+		return errors.Wrap(err, "during put for release")
+	}
+	return nil
+}
+
+// Unlock cancels the lock and closes any running goroutines.
+func (l *lock) Unlock(b []byte) {
+	l.cfg.Log.Infof("Unlock(%s)\n", string(b))
+	if b != nil {
+		l.cfg.LockOptions.Value = b
+	}
+	l.wg.Stop()
+}
+
+type Mock struct{}
+
+func (*Mock) PutValue(ctx context.Context, b []byte) error { return nil }
+func (*Mock) Unlock(b []byte)                              {}
+func (*Mock) HasLock() bool                                { return true }

--- a/consul/lock_test.go
+++ b/consul/lock_test.go
@@ -1,0 +1,249 @@
+package consul_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/Shopify/toxiproxy"
+	"github.com/hashicorp/consul/api"
+	"github.com/mailgun/holster/v3/consul"
+	"github.com/mailgun/holster/v3/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func cleanUp() {
+	client, _ := api.NewClient(api.DefaultConfig())
+	list, _, _ := client.KV().List("lock-test", nil)
+	for _, pair := range list {
+		client.KV().Delete(pair.Key, nil)
+	}
+}
+
+func WithToxiProxy(t *testing.T, fn func(*toxiproxy.Proxy, *api.Client)) {
+	proxy := toxiproxy.NewProxy()
+	proxy.Name = fmt.Sprintf("consul-proxy-%d", rand.Int())
+	proxy.Listen = "127.0.0.1:0"
+	proxy.Upstream = "127.0.0.1:8500"
+
+	err := proxy.Start()
+	defer proxy.Stop()
+	require.NoError(t, err)
+
+	cfg := api.DefaultConfig()
+	cfg.Address = proxy.Listen
+	c, err := api.NewClient(cfg)
+	require.NoError(t, err)
+	fn(proxy, c)
+}
+
+func printKeys(prefix string) {
+	print := "-----------------\n"
+	client, _ := api.NewClient(api.DefaultConfig())
+	list, _, _ := client.KV().List(prefix, nil)
+	for _, pair := range list {
+		print = print + fmt.Sprintf("Pair: %s:%s\n", pair.Key, string(pair.Value))
+	}
+	fmt.Print(print + "-----\n")
+}
+
+func TestBehaviorRelease(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	hasLockCh := make(chan bool, 5)
+	defer cleanUp()
+
+	WithToxiProxy(t, func(p *toxiproxy.Proxy, c *api.Client) {
+		printKeys("lock-test")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		defer cancel()
+		name := fmt.Sprintf("lock-test-%d", rand.Int())
+		l, err := consul.SpawnLock(ctx, &consul.LockConfig{
+			Client: c,
+			LockOptions: &api.LockOptions{
+				SessionOpts: &api.SessionEntry{
+					Name:      name,
+					LockDelay: time.Second * 10,
+					Behavior:  api.SessionBehaviorRelease,
+					TTL:       "10s",
+				},
+				Value:       []byte("lock-value"),
+				SessionName: name,
+				Key:         name,
+			},
+			OnChange: func(hasLock bool) {
+				hasLockCh <- hasLock
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, l)
+
+		// Should have lock
+		printKeys("lock-test")
+		require.True(t, l.HasLock())
+		select {
+		case is := <-hasLockCh:
+			assert.True(t, is)
+		default:
+		}
+
+		// Interrupt connectivity to consul
+		p.Stop()
+
+		// Ensure the connectivity is broken
+		_, _, err = c.KV().Get(name, nil)
+		assert.Error(t, err)
+
+		// Wait until we notice we lost lock
+		is := <-hasLockCh
+		assert.False(t, is)
+		assert.False(t, l.HasLock())
+		printKeys("lock-test")
+
+		// Resume connectivity
+		err = p.Start()
+		require.NoError(t, err)
+
+		// Wait until we regain lock
+		is = <-hasLockCh
+		assert.True(t, is)
+		assert.True(t, l.HasLock())
+
+		// Unlock the key
+		l.Unlock([]byte("this is a test"))
+		printKeys("lock-test")
+
+		// Ensure the key is NOT deleted
+		list, _, err := c.KV().List("lock-test", nil)
+		require.NoError(t, err)
+		var found bool
+		for _, i := range list {
+			if i.Key == name {
+				found = true
+				assert.Equal(t, i.Value, []byte("this is a test"))
+			}
+		}
+		assert.True(t, found)
+
+		// Delete the key
+		_, err = c.KV().Delete(name, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestBehaviorDeleteOnUnlock(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	hasLockCh := make(chan bool, 5)
+	defer cleanUp()
+
+	WithToxiProxy(t, func(p *toxiproxy.Proxy, c *api.Client) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		defer cancel()
+		name := fmt.Sprintf("lock-test-delete-%d", rand.Int())
+		l, err := consul.SpawnLock(ctx, &consul.LockConfig{
+			Client: c,
+			LockOptions: &api.LockOptions{
+				SessionOpts: &api.SessionEntry{
+					Name:      name,
+					LockDelay: time.Second * 10,
+					// When SessionBehavior is Delete
+					Behavior: api.SessionBehaviorDelete,
+					TTL:      "10s",
+				},
+				Value:       []byte("lock-value"),
+				SessionName: name,
+				Key:         name,
+			},
+			OnChange: func(hasLock bool) {
+				hasLockCh <- hasLock
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, l)
+
+		// Should have lock
+		require.True(t, l.HasLock())
+		select {
+		case is := <-hasLockCh:
+			assert.True(t, is)
+		default:
+		}
+
+		// Unlock the key
+		l.Unlock(nil)
+		printKeys("lock-test")
+
+		// Ensure the key was deleted
+		list, _, err := c.KV().List("lock-test", nil)
+		require.NoError(t, err)
+		var found bool
+		for _, i := range list {
+			if i.Key == name {
+				found = true
+			}
+		}
+		assert.False(t, found)
+	})
+}
+
+func TestBehaviorDeleteOnDisconnect(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	defer cleanUp()
+
+	WithToxiProxy(t, func(p *toxiproxy.Proxy, c *api.Client) {
+		printKeys("lock-test")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		defer cancel()
+		name := fmt.Sprintf("lock-test-disconnect%d", rand.Int())
+		l, err := consul.SpawnLock(ctx, &consul.LockConfig{
+			Client: c,
+			LockOptions: &api.LockOptions{
+				SessionOpts: &api.SessionEntry{
+					Name: name,
+					// When SessionBehavior is Delete
+					Behavior: api.SessionBehaviorDelete,
+					TTL:      "10s",
+				},
+				Value:       []byte("lock-value"),
+				SessionName: name,
+				Key:         name,
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, l)
+
+		// Should have lock
+		printKeys("lock-test")
+		require.True(t, l.HasLock())
+
+		// Interrupt connectivity to consul
+		p.Stop()
+
+		// Wait for the lock file to disappear
+		client, err := api.NewClient(api.DefaultConfig())
+		testutil.UntilPass(t, 50, time.Second, func(t testutil.TestingT) {
+			kv, _, err := client.KV().Get(name, nil)
+			assert.NoError(t, err)
+			assert.Nil(t, kv)
+		})
+
+		// Resume connectivity
+		err = p.Start()
+		require.NoError(t, err)
+
+		// Wait until we regain lock
+		testutil.UntilPass(t, 50, time.Second, func(t testutil.TestingT) {
+			assert.True(t, l.HasLock())
+		})
+
+		// Unlock the key
+		l.Unlock(nil)
+	})
+}


### PR DESCRIPTION
## Purpose
`Lock` creates a lock file that attempts to keep the lock on the file until told to stop, even if connectivity is lost. This is a general purpose tool for coordination and can be used to gain exclusive access to a shared resource, or keep a key value pair in the KV store for the life of a service. (example: vulcand registration). It can also be used to implement a simple leader election, where the client ALWAYS attempts to reconnect and gain ownership of the lock unless told to stop.  This Implementation will however fail on the first attempt if no connectivity to consul exists. `mailgun/service` leader election has no such limitation. 

## Implementation
* Using the `SessionOpts.Behavior` users can dictate if the file should be deleted when `Unlock()` is called or if connectivity is lost. 

