### PR TITLE
PIP-1359: add StringWithOffset method to RFC822Time struct

### DIFF
--- a/clock/rfc822.go
+++ b/clock/rfc822.go
@@ -80,3 +80,7 @@ func (t *RFC822Time) UnmarshalJSON(s []byte) error {
 func (t RFC822Time) String() string {
 	return t.Format(RFC1123)
 }
+
+func (t RFC822Time) StringWithOffset() string {
+	return t.Format(RFC1123Z)
+}

--- a/clock/rfc822_test.go
+++ b/clock/rfc822_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -161,4 +162,10 @@ func TestParseRFC822Time(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestStringWithOffset(t *testing.T) {
+	now := time.Now().UTC()
+	r := NewRFC822Time(now)
+	assert.Equal(t, now.Format(time.RFC1123Z), r.StringWithOffset())
 }


### PR DESCRIPTION
### Purpose
Update RFC822Time struct to have method to return numerical offset of timezone. 

https://mailgun.atlassian.net/browse/PIP-1359