### PR TITLE
PIP-1487: make seconds optional for parsing RFC822 timestamps

### DIFF
--- a/clock/rfc822.go
+++ b/clock/rfc822.go
@@ -22,11 +22,22 @@ func ParseRFC822Time(s string) (Time, error) {
 	if err == nil {
 		return t, err
 	}
-	if parseErr, ok := err.(*ParseError); !ok {
-		return Time{}, parseErr
+	if _, ok := err.(*ParseError); !ok {
+		return Time{}, err
 	}
-
-	return parseRFC822Time(s)
+	if t, err = parseRFC822Time(s); err == nil {
+		return t, err
+	}
+	if _, ok := err.(*ParseError); !ok {
+		return Time{}, err
+	}
+	if t, err = parseRFC822TimeAbreviatedNoSeconds(s); err == nil {
+		return t, err
+	}
+	if _, ok := err.(*ParseError); !ok {
+		return Time{}, err
+	}
+	return parseRFC822TimeNoSeconds(s)
 }
 
 // parseRFC822TimeAbbreviated attempts to parse a an RFC822 time with the month abbreviated.
@@ -68,6 +79,44 @@ func parseRFC822TimeAbreviated(s string) (Time, error) {
 	return Time{}, err
 }
 
+func parseRFC822TimeAbreviatedNoSeconds(s string) (Time, error) {
+	t, err := Parse("Mon, 2 Jan 2006 15:04 MST", s)
+	if err == nil {
+		return t, nil
+	}
+	if parseErr, ok := err.(*ParseError); !ok || (parseErr.LayoutElem != "MST" && parseErr.LayoutElem != "Mon") {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("Mon, 2 Jan 2006 15:04 -0700", s); err == nil {
+		return t, nil
+	}
+	if parseErr, ok := err.(*ParseError); !ok || (parseErr.LayoutElem != "" && parseErr.LayoutElem != "Mon") {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("Mon, 2 Jan 2006 15:04 -0700 (MST)", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "Mon" {
+		return Time{}, err
+	}
+	if t, err = Parse("2 Jan 2006 15:04 MST", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "MST" {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("2 Jan 2006 15:04 -0700", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "" {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("2 Jan 2006 15:04 -0700 (MST)", s); err == nil {
+		return t, err
+	}
+	return Time{}, err
+}
+
 // parseRFC822Time attempts to parse an RFC822 time with the full month name.
 func parseRFC822Time(s string) (Time, error) {
 	t, err := Parse("Mon, 2 January 2006 15:04:05 MST", s)
@@ -102,6 +151,44 @@ func parseRFC822Time(s string) (Time, error) {
 		return Time{}, parseErr
 	}
 	if t, err = Parse("2 January 2006 15:04:05 -0700 (MST)", s); err == nil {
+		return t, err
+	}
+	return Time{}, err
+}
+
+func parseRFC822TimeNoSeconds(s string) (Time, error) {
+	t, err := Parse("Mon, 2 January 2006 15:04 MST", s)
+	if err == nil {
+		return t, nil
+	}
+	if parseErr, ok := err.(*ParseError); !ok || (parseErr.LayoutElem != "MST" && parseErr.LayoutElem != "Mon") {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("Mon, 2 January 2006 15:04 -0700", s); err == nil {
+		return t, nil
+	}
+	if parseErr, ok := err.(*ParseError); !ok || (parseErr.LayoutElem != "" && parseErr.LayoutElem != "Mon") {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("Mon, 2 January 2006 15:04 -0700 (MST)", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "Mon" {
+		return Time{}, err
+	}
+	if t, err = Parse("2 January 2006 15:04 MST", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "MST" {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("2 January 2006 15:04 -0700", s); err == nil {
+		return t, err
+	}
+	if parseErr, ok := err.(*ParseError); !ok || parseErr.LayoutElem != "" {
+		return Time{}, parseErr
+	}
+	if t, err = Parse("2 January 2006 15:04 -0700 (MST)", s); err == nil {
 		return t, err
 	}
 	return Time{}, err

--- a/clock/rfc822_test.go
+++ b/clock/rfc822_test.go
@@ -137,10 +137,10 @@ func TestRFC822UnmarshalingError(t *testing.T) {
 		outError  string
 	}{{
 		inEncoded: `{"ts": "Thu, 29 Aug 2019 11:20:07"}`,
-		outError:  `parsing time "Thu, 29 Aug 2019 11:20:07" as "Mon, 2 January 2006 15:04:05 MST": cannot parse "Aug 2019 11:20:07" as "January"`,
+		outError:  `parsing time "Thu, 29 Aug 2019 11:20:07" as "Mon, 2 January 2006 15:04 MST": cannot parse "Aug 2019 11:20:07" as "January"`,
 	}, {
 		inEncoded: `{"ts": "foo"}`,
-		outError:  `parsing time "foo" as "2 January 2006 15:04:05 MST": cannot parse "foo" as "2"`,
+		outError:  `parsing time "foo" as "2 January 2006 15:04 MST": cannot parse "foo" as "2"`,
 	}, {
 		inEncoded: `{"ts": 42}`,
 		outError:  "invalid syntax",
@@ -170,6 +170,22 @@ func TestParseRFC822Time(t *testing.T) {
 		{"2 June 2021 17:06:41 GMT"},
 		{"2 June 2021 17:06:41 -0700"},
 		{"2 June 2021 17:06:41 -0700 (MST)"},
+
+		// Timestamps without seconds.
+		{"Sun, 31 Oct 2021 12:10 -5000"},
+		{"Thu, 3 Jun 2021 12:01 MST"},
+		{"Thu, 3 Jun 2021 12:01 -0700"},
+		{"Thu, 3 Jun 2021 12:01 -0700 (MST)"},
+		{"2 Jun 2021 17:06 GMT"},
+		{"2 Jun 2021 17:06 -0700"},
+		{"2 Jun 2021 17:06 -0700 (MST)"},
+		{"Mon, 30 August 2021 11:05 -0400"},
+		{"Thu, 3 June 2021 12:01 MST"},
+		{"Thu, 3 June 2021 12:01 -0700"},
+		{"Thu, 3 June 2021 12:01 -0700 (MST)"},
+		{"2 June 2021 17:06 GMT"},
+		{"2 June 2021 17:06 -0700"},
+		{"2 June 2021 17:06 -0700 (MST)"},
 	} {
 		t.Run(tt.rfc822Time, func(t *testing.T) {
 			_, err := ParseRFC822Time(tt.rfc822Time)


### PR DESCRIPTION
### Purpose
Some customers are omitting the seconds in a rfc2822 datetime, which per the rfc is optional. Holster should support rfc2822 datetime without seconds. 

> The time-of-day specifies the number of hours, minutes, and
>    optionally seconds since midnight of the date indicated.

https://datatracker.ietf.org/doc/html/rfc2822.html#page-14 

https://mailgun.atlassian.net/browse/PIP-1487