### PR TITLE
Add test for errors.Is()

### DIFF
--- a/errors/go113.go
+++ b/errors/go113.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package errors

--- a/errors/go113_test.go
+++ b/errors/go113_test.go
@@ -1,3 +1,6 @@
+//go:build go1.13
+// +build go1.13
+
 package errors
 
 import (

--- a/errors/go113_test.go
+++ b/errors/go113_test.go
@@ -29,6 +29,11 @@ func TestIs(t *testing.T) {
 			err:    Wrap(Wrap(target, "reason2"), "reason1"),
 		},
 		{
+			name:   "holster_triple_wrap",
+			target: target,
+			err:    Wrap(Wrap(Wrap(target, "reason3"), "reason2"), "reason1"),
+		},
+		{
 			name:   "std_wrap",
 			target: target,
 			err:    fmt.Errorf("some reason: %w", target),

--- a/errors/go113_test.go
+++ b/errors/go113_test.go
@@ -24,9 +24,19 @@ func TestIs(t *testing.T) {
 			err:    Wrap(target, "some reason"),
 		},
 		{
+			name:   "holster_double_wrap",
+			target: target,
+			err:    Wrap(Wrap(target, "reason2"), "reason1"),
+		},
+		{
 			name:   "std_wrap",
 			target: target,
 			err:    fmt.Errorf("some reason: %w", target),
+		},
+		{
+			name:   "std_double_wrap",
+			target: target,
+			err:    fmt.Errorf("reason1: %w", fmt.Errorf("reason2: %w", target)),
 		},
 	}
 

--- a/errors/go113_test.go
+++ b/errors/go113_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIs(t *testing.T) {
+	target := New("wrapped")
+
+	err := Wrap(target, "some reason")
+
+	is := Is(err, target)
+	assert.True(t, is)
+	assert.ErrorIs(t, err, target)
+}
+
+func TestStdIs(t *testing.T) {
+	target := New("wrapped")
+
+	err := fmt.Errorf("some reason: %w", target)
+
+	is := Is(err, target)
+	assert.True(t, is)
+	assert.ErrorIs(t, err, target)
+}

--- a/errors/go113_test.go
+++ b/errors/go113_test.go
@@ -10,19 +10,27 @@ import (
 func TestIs(t *testing.T) {
 	target := New("wrapped")
 
-	err := Wrap(target, "some reason")
+	tests := []struct {
+		name   string
+		target error
+		err    error
+	}{
+		{
+			name:   "holster_wrap",
+			target: target,
+			err:    Wrap(target, "some reason"),
+		},
+		{
+			name:   "std_wrap",
+			target: target,
+			err:    fmt.Errorf("some reason: %w", target),
+		},
+	}
 
-	is := Is(err, target)
-	assert.True(t, is)
-	assert.ErrorIs(t, err, target)
-}
-
-func TestStdIs(t *testing.T) {
-	target := New("wrapped")
-
-	err := fmt.Errorf("some reason: %w", target)
-
-	is := Is(err, target)
-	assert.True(t, is)
-	assert.ErrorIs(t, err, target)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, Is(tt.err, tt.target))
+			assert.ErrorIs(t, tt.err, tt.target)
+		})
+	}
 }


### PR DESCRIPTION
```
# go test -p 1 ./errors/... -race -timeout 1m --count=1

--- FAIL: TestIs (0.00s)
    --- FAIL: TestIs/holster_wrap (0.00s)
        go113_test.go:35:
            	Error Trace:	go113_test.go:35
            	Error:      	Should be true
            	Test:       	TestIs/holster_wrap
        go113_test.go:36:
            	Error Trace:	go113_test.go:36
            	Error:      	Target error should be in err chain:
            	            	expected: "wrapped"
            	            	in chain: "some reason: wrapped"
            	Test:       	TestIs/holster_wrap
FAIL
FAIL	github.com/mailgun/holster/v4/errors	5.011s
```