### PR TITLE
PIP-1618: Simplify OTel resource configuration.

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -147,14 +147,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
-res, err := resource.Merge(
-	resource.Default(),
-	resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey.String("My service"),
-		semconv.ServiceVersionKey.String("v1.0.0"),
-	),
-)
+res, err := tracing.NewResource("My service", "v1.0.0")
 ctx, tracer, err := tracing.InitTracing(ctx, "github.com/myrepo/myservice", sdktrace.WithResource(res))
 ```
 


### PR DESCRIPTION
https://mailgun.atlassian.net/browse/PIP-1618

Simplify most common use case of OTel initialization using `tracing.NewResource()`.

before:
```
res, err := resource.Merge(
       resource.Default(),
       resource.NewWithAttributes(
               semconv.SchemaURL,
               semconv.ServiceNameKey.String("My service"),
               semconv.ServiceVersionKey.String("v1.0.0"),
       ),
)
ctx, tracer, err := tracing.InitTracing(ctx, "github.com/myrepo/myservice", sdktrace.WithResource(res))
```

after:
```
res, err := tracing.NewResource("My service", "v1.0.0")
ctx, tracer, err := tracing.InitTracing(ctx, "github.com/myrepo/myservice", sdktrace.WithResource(res))
```