### PR TITLE
add helper func to mongoutil for time-tagging mongo documents

### DIFF
--- a/mongoutil/uri.go
+++ b/mongoutil/uri.go
@@ -2,11 +2,19 @@ package mongoutil
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/mailgun/holster/v4/clock"
+	"github.com/mailgun/holster/v4/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/bsonx"
 )
 
 type Config struct {
@@ -122,4 +130,36 @@ func toCamelCase(s string) string {
 		buf.WriteRune(ch)
 	}
 	return buf.String()
+}
+
+// TimeTagDocument can be used to add a creation timestamp attribute `_tim` and
+// to add or update an `updated_at` timestamp when it is called with reference
+// to a single mongo document.
+// Cf. https://github.com/mailgun/flagman/blob/92ffbc4/flagman/model/mixin.py#L51-L71
+// Unlike in the above example's Python implementation, this func must be explicitly called
+// immediately after document creation and every subsequent update to provide the same utility.
+//
+// id should be the value of the `_id` field assigned by mongodb to every document by default
+// c must be the mongo document collection that contains the document identified by the id argument
+// postInit should be true when this is being called immediately after document creation
+func TimeTagDocument(ctx context.Context, id primitive.ObjectID, c *mongo.Collection, postInit bool) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*clock.Second)
+	defer cancel()
+
+	var update primitive.M
+	now := bsonx.DateTime(clock.Now().UTC().UnixNano() / 1e6)
+	filter := bson.M{"_id": id}
+
+	if postInit {
+		update = bson.M{"$set": bson.M{"_tim": now, "updated_at": now}}
+	} else {
+		update = bson.M{"$set": bson.M{"updated_at": now}}
+	}
+	if _, err := c.FindOneAndUpdate(ctx, filter, update, nil).DecodeBytes(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return errors.Wrap(err, fmt.Sprintf("document %s from collection %s not found", id, c.Name()))
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Working implementation [here](https://github.com/mailgun/cerberus/blob/66e24a568a7507595fa1fed2ffb0f48f9737b125/api/mailgun_auth_test.go#L83).

In MongoDB:
```mongo
> db.api_keys.find()
{ "_id" : ObjectId("000000000000000000000000"), "_tim" : ISODate("2022-08-10T17:10:32.438Z"), "updated_at" : ISODate("2022-08-10T17:10:32.438Z"), "account_id" : ...
```