### PR TITLE
PIP-2108: Lint 4/4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
     - errcheck # Mandatory. Do not disable.
     - gocritic
     - goimports
-    # - gosec
+    - gosec
     # - gosimple
     # - govet
     # - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - depguard
     - errcheck # Mandatory. Do not disable.
     - gocritic
-    # - goimports
+    - goimports
     # - gosec
     # - gosimple
     # - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - govet
     # - noctx
     - nolintlint
-    # - ineffassign # Mandatory. Do not disable.
+    - ineffassign # Mandatory. Do not disable.
     # - staticcheck # Mandatory. Do not disable.
     # - stylecheck
     # - typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - goimports
     - gosec
     - gosimple
-    # - govet
+    - govet
     # - noctx
     - nolintlint
     # - ineffassign # Mandatory. Do not disable.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     # - noctx
     - nolintlint
     - ineffassign # Mandatory. Do not disable.
-    # - staticcheck # Mandatory. Do not disable.
+    - staticcheck # Mandatory. Do not disable.
     # - stylecheck
     # - typecheck
     # - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - gosec
     - gosimple
     - govet
-    # - noctx
+    - noctx
     - nolintlint
     - ineffassign # Mandatory. Do not disable.
     - staticcheck # Mandatory. Do not disable.
@@ -104,6 +104,13 @@ issues:
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 50
+
+  exclude-rules:
+    # Exclude some rules from tests.
+    - path: '_test\.go$'
+      linters:
+        - gosec
+        - noctx
 
 run:
   # include test files or not, default is true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,9 +16,9 @@ linters:
     - nolintlint
     - ineffassign # Mandatory. Do not disable.
     - staticcheck # Mandatory. Do not disable.
-    # - stylecheck
-    # - typecheck
-    # - unused
+    - stylecheck
+    - typecheck
+    - unused
 
 # Other linters:
 #    - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - gocritic
     - goimports
     - gosec
-    # - gosimple
+    - gosimple
     # - govet
     # - noctx
     - nolintlint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ GOLINT = $(GOPATH)/bin/golangci-lint
 
 .PHONY: lint
 lint: $(GOLINT)
-	go vet ./...
 	$(GOLINT) run
 
 $(GOLINT):

--- a/anonymize/anonymize_test.go
+++ b/anonymize/anonymize_test.go
@@ -1,8 +1,9 @@
 package anonymize
 
 import (
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type AnonymizeSuite struct {

--- a/clock/system.go
+++ b/clock/system.go
@@ -59,6 +59,9 @@ func (st *systemTime) NewTicker(d time.Duration) Ticker {
 	return &systemTicker{t}
 }
 
+// Tick creates a new Ticker and returns ticker channel.
+// Use sparingly or in unit tests as this potentially generates a resource leak.
+// https://staticcheck.io/docs/checks#SA1015
 func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
 	//nolint: staticcheck // FIXME: SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here
 	return time.Tick(d)

--- a/clock/system.go
+++ b/clock/system.go
@@ -60,7 +60,7 @@ func (st *systemTime) NewTicker(d time.Duration) Ticker {
 }
 
 func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
-	// nolint: staticcheck
+	//nolint: staticcheck // FIXME: SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here
 	return time.Tick(d)
 }
 

--- a/clock/system.go
+++ b/clock/system.go
@@ -60,6 +60,7 @@ func (st *systemTime) NewTicker(d time.Duration) Ticker {
 }
 
 func (st *systemTime) Tick(d time.Duration) <-chan time.Time {
+	// nolint: staticcheck
 	return time.Tick(d)
 }
 

--- a/clock/system_test.go
+++ b/clock/system_test.go
@@ -66,7 +66,7 @@ func TestTimerStop(t *testing.T) {
 
 	// Then
 	assert.Equal(t, true, active)
-	time.Sleep(100)
+	time.Sleep(100 * time.Nanosecond)
 	select {
 	case <-timer.C():
 		assert.Fail(t, "Timer should not have fired")

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -26,7 +26,7 @@ func sendRPC(ctx context.Context, peer string, req election.RPCRequest, resp *el
 	}
 
 	// Create a new http request with context
-	hr, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/rpc", peer), bytes.NewBuffer(b))
+	hr, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://%s/rpc", peer), bytes.NewBuffer(b))
 	if err != nil {
 		return errors.Wrap(err, "while creating request")
 	}

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -30,7 +30,6 @@ func sendRPC(ctx context.Context, peer string, req election.RPCRequest, resp *el
 	if err != nil {
 		return errors.Wrap(err, "while creating request")
 	}
-	hr.WithContext(ctx)
 
 	// Send the request
 	hp, err := http.DefaultClient.Do(hr)

--- a/cmd/election/main.go
+++ b/cmd/election/main.go
@@ -134,7 +134,12 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/rpc", newHandler(node))
 	go func() {
-		logrus.Fatal(http.ListenAndServe(electionAddr, mux))
+		server := &http.Server{
+			Addr:              electionAddr,
+			Handler:           mux,
+			ReadHeaderTimeout: 1 * time.Minute,
+		}
+		logrus.Fatal(server.ListenAndServe())
 	}()
 
 	// Wait until the http server is up and can receive RPC requests

--- a/collections/ttlmap.go
+++ b/collections/ttlmap.go
@@ -99,7 +99,7 @@ func (m *TTLMap) Increment(key string, value, ttlSeconds int) (retval int, reter
 
 	currentValue, ok := mapEl.value.(int)
 	if !ok {
-		return 0, fmt.Errorf("expected existing value to be integer, got %T", mapEl.value)
+		return 0, fmt.Errorf("Expected existing value to be integer, got %T", mapEl.value) //nolint:stylecheck // TODO(v5): ST1005: error strings should not be capitalized
 	}
 
 	currentValue += value
@@ -114,7 +114,7 @@ func (m *TTLMap) GetInt(key string) (retval int, found bool, reterr error) {
 	}
 	value, ok := valueI.(int)
 	if !ok {
-		return 0, false, fmt.Errorf("expected existing value to be integer, got %T", valueI)
+		return 0, false, fmt.Errorf("Expected existing value to be integer, got %T", valueI) //nolint:stylecheck // TODO(v5): ST1005: error strings should not be capitalized
 	}
 	return value, true, nil
 }

--- a/collections/ttlmap.go
+++ b/collections/ttlmap.go
@@ -99,7 +99,7 @@ func (m *TTLMap) Increment(key string, value, ttlSeconds int) (retval int, reter
 
 	currentValue, ok := mapEl.value.(int)
 	if !ok {
-		return 0, fmt.Errorf("Expected existing value to be integer, got %T", mapEl.value)
+		return 0, fmt.Errorf("expected existing value to be integer, got %T", mapEl.value)
 	}
 
 	currentValue += value
@@ -114,7 +114,7 @@ func (m *TTLMap) GetInt(key string) (retval int, found bool, reterr error) {
 	}
 	value, ok := valueI.(int)
 	if !ok {
-		return 0, false, fmt.Errorf("Expected existing value to be integer, got %T", valueI)
+		return 0, false, fmt.Errorf("expected existing value to be integer, got %T", valueI)
 	}
 	return value, true, nil
 }

--- a/collections/ttlmap.go
+++ b/collections/ttlmap.go
@@ -140,7 +140,6 @@ func (m *TTLMap) set(key string, value interface{}, expiryTime int) {
 	heapEl.Value = mapEl
 	m.elements[key] = mapEl
 	m.expiryTimes.Push(heapEl)
-	return
 }
 
 func (m *TTLMap) lockNGet(key string) (value interface{}, mapEl *mapElement, expired bool) {

--- a/collections/ttlmap_test.go
+++ b/collections/ttlmap_test.go
@@ -166,10 +166,10 @@ func (s *TTLMapSuite) TestGetInvalidType() {
 	s.Require().NoError(err)
 
 	_, _, err = m.GetInt("a")
-	s.Require().EqualError(err, "Expected existing value to be integer, got string")
+	s.Require().EqualError(err, "expected existing value to be integer, got string")
 
 	_, err = m.Increment("a", 4, 1)
-	s.Require().EqualError(err, "Expected existing value to be integer, got string")
+	s.Require().EqualError(err, "expected existing value to be integer, got string")
 }
 
 func (s *TTLMapSuite) TestIncrementGetExpire() {

--- a/collections/ttlmap_test.go
+++ b/collections/ttlmap_test.go
@@ -166,10 +166,10 @@ func (s *TTLMapSuite) TestGetInvalidType() {
 	s.Require().NoError(err)
 
 	_, _, err = m.GetInt("a")
-	s.Require().EqualError(err, "expected existing value to be integer, got string")
+	s.Require().EqualError(err, "Expected existing value to be integer, got string")
 
 	_, err = m.Increment("a", 4, 1)
-	s.Require().EqualError(err, "expected existing value to be integer, got string")
+	s.Require().EqualError(err, "Expected existing value to be integer, got string")
 }
 
 func (s *TTLMapSuite) TestIncrementGetExpire() {

--- a/collections/ttlmap_test.go
+++ b/collections/ttlmap_test.go
@@ -109,10 +109,10 @@ func (s *TTLMapSuite) TestRemoveExpiredEdgeCase() {
 	err = m.Set("b", 2, 1)
 	s.Require().Equal(nil, err)
 
-	valI, exists := m.Get("a")
+	_, exists := m.Get("a")
 	s.Require().Equal(false, exists)
 
-	valI, exists = m.Get("b")
+	valI, exists := m.Get("b")
 	s.Require().Equal(true, exists)
 	s.Require().Equal(2, valI)
 
@@ -133,10 +133,10 @@ func (s *TTLMapSuite) TestRemoveOutOfCapacity() {
 	err = m.Set("c", 3, 10)
 	s.Require().Equal(nil, err)
 
-	valI, exists := m.Get("a")
+	_, exists := m.Get("a")
 	s.Require().Equal(false, exists)
 
-	valI, exists = m.Get("b")
+	valI, exists := m.Get("b")
 	s.Require().Equal(true, exists)
 	s.Require().Equal(2, valI)
 
@@ -233,7 +233,7 @@ func (s *TTLMapSuite) TestIncrementOutOfCapacity() {
 	s.Require().Equal(true, exists)
 	s.Require().Equal(4, val)
 
-	val, exists, err = m.GetInt("a")
+	_, exists, err = m.GetInt("a")
 
 	s.Require().Equal(nil, err)
 	s.Require().Equal(false, exists)
@@ -251,12 +251,12 @@ func (s *TTLMapSuite) TestIncrementRemovesExpired() {
 	_, err = m.Increment("c", 3, 3)
 	s.Require().NoError(err)
 
-	val, exists, err := m.GetInt("a")
+	_, exists, err := m.GetInt("a")
 
 	s.Require().Equal(nil, err)
 	s.Require().Equal(false, exists)
 
-	val, exists, err = m.GetInt("b")
+	val, exists, err := m.GetInt("b")
 	s.Require().Equal(nil, err)
 	s.Require().Equal(true, exists)
 	s.Require().Equal(2, val)
@@ -277,12 +277,12 @@ func (s *TTLMapSuite) TestIncrementRemovesLastUsed() {
 	_, err = m.Increment("c", 3, 12)
 	s.Require().NoError(err)
 
-	val, exists, err := m.GetInt("a")
+	_, exists, err := m.GetInt("a")
 
 	s.Require().Equal(nil, err)
 	s.Require().Equal(false, exists)
 
-	val, exists, err = m.GetInt("b")
+	val, exists, err := m.GetInt("b")
 	s.Require().Equal(nil, err)
 	s.Require().Equal(true, exists)
 

--- a/consul/config_test.go
+++ b/consul/config_test.go
@@ -25,6 +25,7 @@ func TestNewClientTLS(t *testing.T) {
 	_, err = client.KV().Put(&kv, nil)
 	require.NoError(t, err)
 	resp, _, err := client.KV().Get("test-key-tls", nil)
+	require.NoError(t, err)
 	assert.Equal(t, resp.Key, "test-key-tls")
 	assert.Equal(t, resp.Value, []byte("test-value-tls"))
 }
@@ -40,6 +41,7 @@ func TestNewClient(t *testing.T) {
 	_, err = client.KV().Put(&kv, nil)
 	require.NoError(t, err)
 	resp, _, err := client.KV().Get("test-key", nil)
+	require.NoError(t, err)
 	assert.Equal(t, resp.Key, "test-key")
 	assert.Equal(t, resp.Value, []byte("test-value"))
 }

--- a/consul/lock_test.go
+++ b/consul/lock_test.go
@@ -1,4 +1,3 @@
-// #nosec
 package consul_test
 
 import (

--- a/consul/lock_test.go
+++ b/consul/lock_test.go
@@ -1,3 +1,4 @@
+// #nosec
 package consul_test
 
 import (

--- a/consul/lock_test.go
+++ b/consul/lock_test.go
@@ -230,6 +230,7 @@ func TestBehaviorDeleteOnDisconnect(t *testing.T) {
 
 		// Wait for the lock file to disappear
 		client, err := api.NewClient(api.DefaultConfig())
+		require.NoError(t, err)
 		testutil.UntilPass(t, 50, time.Second, func(t testutil.TestingT) {
 			kv, _, err := client.KV().Get(name, nil)
 			assert.NoError(t, err)

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -2,25 +2,23 @@ package discovery_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/mailgun/holster/v4/discovery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func printCatalog(t *testing.T, catalog string, client *api.Client) {
-	t.Helper()
-	fmt.Printf("============\n")
-	l, _, err := client.Health().Service(catalog, "", false, nil)
-	require.NoError(t, err)
-	for _, i := range l {
-		t.Logf("Service: %s", i.Service.ID)
-	}
-	fmt.Printf("======\n")
-}
+// func printCatalog(t *testing.T, catalog string, client *api.Client) {
+// 	t.Helper()
+// 	fmt.Printf("============\n")
+// 	l, _, err := client.Health().Service(catalog, "", false, nil)
+// 	require.NoError(t, err)
+// 	for _, i := range l {
+// 		t.Logf("Service: %s", i.Service.ID)
+// 	}
+// 	fmt.Printf("======\n")
+// }
 
 func TestConsulSinglePeer(t *testing.T) {
 	const catalog = "TestConsulSinglePeer"

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -39,6 +39,7 @@ func TestConsulSinglePeer(t *testing.T) {
 			onUpdateCh <- peers
 		},
 	})
+	require.NoError(t, err)
 	// printCatalog(t, catalog, client)
 
 	e := <-onUpdateCh

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -9,25 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// func printCatalog(t *testing.T, catalog string, client *api.Client) {
-// 	t.Helper()
-// 	fmt.Printf("============\n")
-// 	l, _, err := client.Health().Service(catalog, "", false, nil)
-// 	require.NoError(t, err)
-// 	for _, i := range l {
-// 		t.Logf("Service: %s", i.Service.ID)
-// 	}
-// 	fmt.Printf("======\n")
-// }
-
 func TestConsulSinglePeer(t *testing.T) {
 	const catalog = "TestConsulSinglePeer"
 	p := discovery.Peer{ID: "id-1", Metadata: []byte("address-0"), IsSelf: true}
 
 	// client, err := api.NewClient(api.DefaultConfig())
 	// require.NoError(t, err)
-
-	// printCatalog(t, catalog, client)
 
 	onUpdateCh := make(chan []discovery.Peer, 1)
 	cs, err := discovery.NewConsul(&discovery.ConsulConfig{
@@ -38,15 +25,12 @@ func TestConsulSinglePeer(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	// printCatalog(t, catalog, client)
 
 	e := <-onUpdateCh
 	assert.Equal(t, p, e[0])
 
 	err = cs.Close(context.Background())
 	require.NoError(t, err)
-
-	// printCatalog(t, catalog, client)
 }
 
 func TestConsulMultiplePeers(t *testing.T) {
@@ -56,8 +40,6 @@ func TestConsulMultiplePeers(t *testing.T) {
 
 	// client, err := api.NewClient(api.DefaultConfig())
 	// require.NoError(t, err)
-
-	// printCatalog(t, catalog, client)
 
 	onUpdateCh := make(chan []discovery.Peer, 2)
 	cs0, err := discovery.NewConsul(&discovery.ConsulConfig{
@@ -73,8 +55,6 @@ func TestConsulMultiplePeers(t *testing.T) {
 	e := <-onUpdateCh
 	assert.Equal(t, e[0], p0)
 
-	// printCatalog(t, catalog, client)
-
 	cs1, err := discovery.NewConsul(&discovery.ConsulConfig{
 		CatalogName: catalog,
 		Peer:        p1,
@@ -84,6 +64,4 @@ func TestConsulMultiplePeers(t *testing.T) {
 
 	e = <-onUpdateCh
 	assert.Equal(t, []discovery.Peer{p0, p1}, e)
-
-	// printCatalog(t, catalog, client)
 }

--- a/discovery/memberlist.go
+++ b/discovery/memberlist.go
@@ -239,7 +239,7 @@ func NewLogWriter(log logrus.FieldLogger) *io.PipeWriter {
 		reader.Close()
 	}()
 	runtime.SetFinalizer(writer, func(w *io.PipeWriter) {
-		writer.Close()
+		w.Close()
 	})
 
 	return writer

--- a/discovery/memberlist.go
+++ b/discovery/memberlist.go
@@ -44,7 +44,6 @@ type MemberList struct {
 	memberList *ml.Memberlist
 	conf       MemberListConfig
 	events     *eventDelegate
-	mutex      sync.Mutex
 }
 
 type MemberListConfig struct {

--- a/election/cluster_test.go
+++ b/election/cluster_test.go
@@ -95,7 +95,7 @@ func (c *TestCluster) Remove(name string) *ClusterNode {
 func (c *TestCluster) updatePeers() {
 	// Build a list of all the peers
 	var peers []string
-	for k, _ := range c.Nodes {
+	for k := range c.Nodes {
 		peers = append(peers, k)
 	}
 

--- a/election/election.go
+++ b/election/election.go
@@ -861,7 +861,7 @@ func (e *node) send(req interface{}) chan RPCResponse {
 
 // randomDuration returns a value that is between the minDur and 2x minDur.
 func randomDuration(minDur time.Duration) time.Duration {
-	return minDur + time.Duration(rand.Int63())%minDur
+	return minDur + time.Duration(rand.Int63())%minDur // #nosec
 }
 
 // WaitForConnect waits for the specified address to accept connections then returns nil.

--- a/election/election.go
+++ b/election/election.go
@@ -859,7 +859,7 @@ func (e *node) send(req interface{}) chan RPCResponse {
 
 // randomDuration returns a value that is between the minDur and 2x minDur.
 func randomDuration(minDur time.Duration) time.Duration {
-	return minDur + time.Duration(rand.Int63())%minDur // #nosec
+	return minDur + time.Duration(rand.Int63())%minDur // #nosec // Cryptographic security not required.
 }
 
 // WaitForConnect waits for the specified address to accept connections then returns nil.

--- a/election/election.go
+++ b/election/election.go
@@ -859,7 +859,7 @@ func (e *node) send(req interface{}) chan RPCResponse {
 
 // randomDuration returns a value that is between the minDur and 2x minDur.
 func randomDuration(minDur time.Duration) time.Duration {
-	return minDur + time.Duration(rand.Int63())%minDur // #nosec // Cryptographic security not required.
+	return minDur + time.Duration(rand.Int63())%minDur //nolint:gosec // Cryptographic security not required.
 }
 
 // WaitForConnect waits for the specified address to accept connections then returns nil.

--- a/election/election.go
+++ b/election/election.go
@@ -322,10 +322,9 @@ func (e *node) Stop(ctx context.Context) error {
 		e.wg.Wait()
 		close(done)
 	}()
-	select {
-	case <-done:
-		return ctx.Err()
-	}
+
+	<-done
+	return ctx.Err()
 }
 
 // Main thread loop
@@ -363,7 +362,7 @@ func (e *node) runFollower() {
 			e.processRPC(rpc)
 		case <-heartbeatTimer.C:
 			// Check if we have had successful contact with the leader
-			if time.Now().Sub(e.lastContact) < e.conf.HeartBeatTimeout {
+			if time.Since(e.lastContact) < e.conf.HeartBeatTimeout {
 				continue
 			}
 
@@ -816,7 +815,6 @@ func (e *node) handleVote(rpc RPCRequest, req VoteReq) {
 	// Tell the requester we voted for him
 	resp.Granted = true
 	e.lastContact = time.Now()
-	return
 }
 
 func (e *node) handleSetPeers(rpc RPCRequest, req SetPeersReq) {

--- a/election/election_test.go
+++ b/election/election_test.go
@@ -409,7 +409,7 @@ func TestResign(t *testing.T) {
 
 	// Calling resign on a follower should have no effect
 	err := c1.Nodes["n1"].Node.Resign(context.Background())
-	require.NoError(t, err)
+	assert.ErrorContains(t, err, "not the leader")
 
 	for i := 0; i < 10; i++ {
 		if c1.GetLeader() != leader {

--- a/election/example_test.go
+++ b/election/example_test.go
@@ -31,7 +31,6 @@ func sendRPC(ctx context.Context, peer string, req election.RPCRequest, resp *el
 	if err != nil {
 		return errors.Wrap(err, "while creating request")
 	}
-	hr.WithContext(ctx)
 
 	// Send the request
 	hp, err := http.DefaultClient.Do(hr)

--- a/election/example_test.go
+++ b/election/example_test.go
@@ -27,7 +27,7 @@ func sendRPC(ctx context.Context, peer string, req election.RPCRequest, resp *el
 	}
 
 	// Create a new http request with context
-	hr, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/rpc", peer), bytes.NewBuffer(b))
+	hr, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://%s/rpc", peer), bytes.NewBuffer(b))
 	if err != nil {
 		return errors.Wrap(err, "while creating request")
 	}

--- a/election/example_test.go
+++ b/election/example_test.go
@@ -109,13 +109,23 @@ func SimpleExample(t *testing.T) {
 	go func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/rpc", newHandler(t, node1))
-		log.Fatal(http.ListenAndServe(":7080", mux))
+		server := &http.Server{
+			Addr:              ":7080",
+			Handler:           mux,
+			ReadHeaderTimeout: 1 * time.Minute,
+		}
+		log.Fatal(server.ListenAndServe())
 	}()
 
 	go func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/rpc", newHandler(t, node2))
-		log.Fatal(http.ListenAndServe(":7081", mux))
+		server := &http.Server{
+			Addr:              ":7081",
+			Handler:           mux,
+			ReadHeaderTimeout: 1 * time.Minute,
+		}
+		log.Fatal(server.ListenAndServe())
 	}()
 
 	// Wait for each of the http listeners to start fielding requests

--- a/election/rpc_test.go
+++ b/election/rpc_test.go
@@ -2,6 +2,7 @@ package election_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -172,6 +173,7 @@ func TestRPCResponse(t *testing.T) {
 }
 
 func TestHTTPServer(t *testing.T) {
+	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var in election.RPCRequest
 
@@ -212,7 +214,7 @@ func TestHTTPServer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Send the request to the server
-	req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewBuffer(b))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL, bytes.NewBuffer(b))
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -234,7 +236,7 @@ func TestHTTPServer(t *testing.T) {
 	assert.Equal(t, "node1", hb.From)
 
 	// Send an unknown rpc request to the server
-	req, err = http.NewRequest(http.MethodPost, ts.URL, bytes.NewBuffer([]byte(`{"rpc":"unknown"}`)))
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, ts.URL, bytes.NewBuffer([]byte(`{"rpc":"unknown"}`)))
 	require.NoError(t, err)
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/election/rpc_test.go
+++ b/election/rpc_test.go
@@ -224,6 +224,7 @@ func TestHTTPServer(t *testing.T) {
 	// Unmarshall the response
 	var rpcResp election.RPCResponse
 	b, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	err = json.Unmarshal(b, &rpcResp)
 	require.NoError(t, err)
 
@@ -244,6 +245,7 @@ func TestHTTPServer(t *testing.T) {
 
 	// Unmarshall the response
 	b, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	err = json.Unmarshal(b, &rpcResp)
 	require.NoError(t, err)
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -311,20 +311,14 @@ func Cause(err error) error {
 func ToMap(err error) map[string]interface{} {
 	var result map[string]interface{}
 
-	// Add context if provided
-	child, ok := err.(HasContext)
-	if !ok {
-		return result
+	if child, ok := err.(HasContext); ok {
+		// Append the context map to our results
+		result = make(map[string]interface{})
+		for key, value := range child.Context() {
+			result[key] = value
+		}
 	}
 
-	if result == nil {
-		return child.Context()
-	}
-
-	// Append the context map to our results
-	for key, value := range child.Context() {
-		result[key] = value
-	}
 	return result
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -100,9 +101,7 @@ func TestCause(t *testing.T) {
 
 	for i, tt := range tests {
 		got := Cause(tt.err)
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
-		}
+		require.ErrorIsf(t, tt.want, got, "test %d: got %#v, want %#v", i+1, got, tt.want)
 	}
 }
 

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -196,7 +196,7 @@ func Example_stackTrace() {
 func ExampleCause_printf() {
 	err := errors.Wrap(func() error {
 		return func() error {
-			return errors.Errorf("hello %s", fmt.Sprintf("world"))
+			return errors.Errorf("hello %s", "world")
 		}()
 	}(), "failed")
 

--- a/errors/typederror.go
+++ b/errors/typederror.go
@@ -4,7 +4,6 @@ package errors
 // Contains error class and type decoration.
 type TypedError struct {
 	error
-	msg string
 	cls string
 	typ string
 }

--- a/etcdutil/config.go
+++ b/etcdutil/config.go
@@ -20,7 +20,7 @@ const (
 func init() {
 	// We check this here to avoid data race with GRPC go routines writing to the logger
 	if os.Getenv("ETCD3_DEBUG") != "" {
-		etcd.SetLogger(grpclog.NewLoggerV2WithVerbosity(os.Stderr, os.Stderr, os.Stderr, 4))
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(os.Stderr, os.Stderr, os.Stderr, 4))
 	}
 }
 

--- a/etcdutil/config.go
+++ b/etcdutil/config.go
@@ -70,9 +70,13 @@ func NewConfig(cfg *etcd.Config) (*etcd.Config, error) {
 		cfg.DialTimeout = duration
 	}
 
+	defaultCfg := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+
 	// If the CA file was provided
 	if tlsCAFile != "" {
-		setter.SetDefault(&cfg.TLS, &tls.Config{})
+		setter.SetDefault(&cfg.TLS, defaultCfg)
 
 		var certPool *x509.CertPool = nil
 		if pemBytes, err := os.ReadFile(tlsCAFile); err == nil {
@@ -87,7 +91,7 @@ func NewConfig(cfg *etcd.Config) (*etcd.Config, error) {
 
 	// If the cert and key files are provided attempt to load them
 	if tlsCertFile != "" && tlsKeyFile != "" {
-		setter.SetDefault(&cfg.TLS, &tls.Config{})
+		setter.SetDefault(&cfg.TLS, defaultCfg)
 		tlsCert, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
 		if err != nil {
 			return nil, errors.Errorf("while loading cert '%s' and key file '%s': %s",
@@ -102,13 +106,13 @@ func NewConfig(cfg *etcd.Config) (*etcd.Config, error) {
 	// If no other TLS config is provided this will force connecting with TLS,
 	// without cert verification
 	if os.Getenv("ETCD3_SKIP_VERIFY") != "" {
-		setter.SetDefault(&cfg.TLS, &tls.Config{})
+		setter.SetDefault(&cfg.TLS, defaultCfg)
 		cfg.TLS.InsecureSkipVerify = true
 	}
 
 	// Enable TLS with no additional configuration
 	if os.Getenv("ETCD3_ENABLE_TLS") != "" {
-		setter.SetDefault(&cfg.TLS, &tls.Config{})
+		setter.SetDefault(&cfg.TLS, defaultCfg)
 	}
 
 	return cfg, nil

--- a/etcdutil/election.go
+++ b/etcdutil/election.go
@@ -338,7 +338,7 @@ func (e *Election) watchCampaign(rev int64) error {
 			for _, event := range resp.Events {
 				if event.Type == etcd.EventTypeDelete || event.Type == etcd.EventTypePut {
 					// If the key is for our current leader
-					if bytes.Compare(event.Kv.Key, leaderKV.Key) == 0 {
+					if bytes.Equal(event.Kv.Key, leaderKV.Key) {
 						// Check our leadership status
 						resp, err := e.getLeader(e.ctx)
 						if err != nil {
@@ -352,7 +352,7 @@ func (e *Election) watchCampaign(rev int64) error {
 							return false
 						}
 						// Notify if leadership has changed
-						if bytes.Compare(resp.Key, leaderKV.Key) != 0 {
+						if !bytes.Equal(resp.Key, leaderKV.Key) {
 							leaderKV = resp
 							e.onLeaderChange(leaderKV)
 						}

--- a/etcdutil/session.go
+++ b/etcdutil/session.go
@@ -97,7 +97,7 @@ func (s *Session) start() {
 			}
 		case <-ticker.C:
 			// Ensure we are getting heartbeats regularly
-			if time.Now().Sub(s.lastKeepAlive) > s.ttl {
+			if time.Since(s.lastKeepAlive) > s.ttl {
 				// too long between heartbeats
 				s.keepAlive = nil
 			}

--- a/httpsign/random_test.go
+++ b/httpsign/random_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var _ = fmt.Printf // for testing
@@ -68,6 +70,7 @@ func TestSeededRNG(t *testing.T) {
 
 	// Test HexDigest().
 	g1, err := rng.hexDigest(4)
+	assert.NoError(t, err)
 	if w := "fa12f92a"; g1 != w {
 		t.Errorf("&SeededRNG{Seed: 0}.Bytes(4) = %v, want %v", g1, w)
 	}

--- a/httpsign/signer.go
+++ b/httpsign/signer.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/mailgun/holster/v4/clock"
 )
@@ -102,20 +101,21 @@ func New(config *Config) (*Signer, error) {
 		config.SignatureVersionHeaderName = XMailgunSignatureVersion
 	}
 
-	// setup metrics service
-	if config.EmitStats {
-		// get hostname of box
-		hostname, err := os.Hostname()
-		if err != nil {
-			return nil, fmt.Errorf("failed to obtain hostname: %v", err)
-		}
-
-		// build lemma prefix
-		prefix := "lemma." + strings.ReplaceAll(hostname, ".", "_")
-		if config.StatsdPrefix != "" {
-			prefix += "." + config.StatsdPrefix
-		}
-	}
+	// Commented out this code because it does effectively nothing.
+	// // setup metrics service
+	// if config.EmitStats {
+	// 	// get hostname of box
+	// 	hostname, err := os.Hostname()
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("failed to obtain hostname: %v", err)
+	// 	}
+	//
+	// 	// build lemma prefix
+	// 	prefix := "lemma." + strings.ReplaceAll(hostname, ".", "_")
+	// 	if config.StatsdPrefix != "" {
+	// 		prefix += "." + config.StatsdPrefix
+	// 	}
+	// }
 
 	// Read in key from KeyPath or if not given, try getting them from KeyBytes.
 	var keyBytes []byte
@@ -186,10 +186,6 @@ func (s *Signer) SignRequestWithKey(r *http.Request, secretKey []byte) error {
 	r.Header.Set(s.config.TimestampHeaderName, timestamp)
 	r.Header.Set(s.config.SignatureHeaderName, signature)
 	r.Header.Set(s.config.SignatureVersionHeaderName, "2")
-
-	// set the body bytes we read in to nil to hint to the gc to pick it up
-	bodyBytes = nil
-
 	return nil
 }
 
@@ -251,9 +247,6 @@ func (s *Signer) VerifyRequestWithKey(r *http.Request, secretKey []byte) (err er
 	if inCache {
 		return fmt.Errorf("nonce already in cache: %v", nonce)
 	}
-
-	// set the body bytes we read in to nil to hint to the gc to pick it up
-	bodyBytes = nil
 
 	return nil
 }

--- a/httpsign/signer.go
+++ b/httpsign/signer.go
@@ -78,7 +78,7 @@ type Signer struct {
 func New(config *Config) (*Signer, error) {
 	// config is required!
 	if config == nil {
-		return nil, fmt.Errorf("config is required.")
+		return nil, fmt.Errorf("config is required")
 	}
 
 	// set defaults if not set
@@ -147,7 +147,7 @@ func New(config *Config) (*Signer, error) {
 // Signs a given HTTP request with signature, nonce, and timestamp.
 func (s *Signer) SignRequest(r *http.Request) error {
 	if s.secretKey == nil {
-		return fmt.Errorf("service not loaded with key.")
+		return fmt.Errorf("service not loaded with key")
 	}
 	return s.SignRequestWithKey(r, s.secretKey)
 }
@@ -192,7 +192,7 @@ func (s *Signer) SignRequestWithKey(r *http.Request, secretKey []byte) error {
 // VerifyRequest checks that an HTTP request was sent by an authorized sender.
 func (s *Signer) VerifyRequest(r *http.Request) error {
 	if s.secretKey == nil {
-		return fmt.Errorf("service not loaded with key.")
+		return fmt.Errorf("service not loaded with key")
 	}
 	return s.VerifyRequestWithKey(r, s.secretKey)
 }
@@ -275,7 +275,7 @@ func (s *Signer) checkTimestamp(timestampHeader string) (bool, error) {
 	return true, nil
 }
 
-func computeMAC(secretKey []byte, signVerbAndUri bool, httpVerb string, httpResourceUri string,
+func computeMAC(secretKey []byte, signVerbAndURI bool, httpVerb string, httpResourceURI string,
 	timestamp string, nonce string, body []byte, headerValues []string) []byte {
 
 	// use hmac-sha256
@@ -290,11 +290,11 @@ func computeMAC(secretKey []byte, signVerbAndUri bool, httpVerb string, httpReso
 	mac.Write(body)
 
 	// optional parameters (httpVerb, httpResourceUri)
-	if signVerbAndUri {
+	if signVerbAndURI {
 		fmt.Fprintf(mac, "|%v|", len(httpVerb))
 		mac.Write([]byte(httpVerb))
-		fmt.Fprintf(mac, "|%v|", len(httpResourceUri))
-		mac.Write([]byte(httpResourceUri))
+		fmt.Fprintf(mac, "|%v|", len(httpResourceURI))
+		mac.Write([]byte(httpResourceURI))
 	}
 
 	// optional parameters (headers)
@@ -306,7 +306,7 @@ func computeMAC(secretKey []byte, signVerbAndUri bool, httpVerb string, httpReso
 	return mac.Sum(nil)
 }
 
-func checkMAC(secretKey []byte, signVerbAndUri bool, httpVerb string, httpResourceUri string,
+func checkMAC(secretKey []byte, signVerbAndURI bool, httpVerb string, httpResourceURI string,
 	timestamp string, nonce string, body []byte, headerValues []string, signature string) (bool, error) {
 
 	// the hmac we get is a hexdigest (string representation of hex values)
@@ -317,7 +317,7 @@ func checkMAC(secretKey []byte, signVerbAndUri bool, httpVerb string, httpResour
 	}
 
 	// compute the hmac
-	computedMAC := computeMAC(secretKey, signVerbAndUri, httpVerb, httpResourceUri, timestamp, nonce, body, headerValues)
+	computedMAC := computeMAC(secretKey, signVerbAndURI, httpVerb, httpResourceURI, timestamp, nonce, body, headerValues)
 
 	// constant time compare
 	isEqual := hmac.Equal(expectedMAC, computedMAC)
@@ -378,7 +378,7 @@ func extractHeaderValues(r *http.Request, headerNames []string) ([]string, error
 	for i, headerName := range headerNames {
 		_, ok := r.Header[headerName]
 		if !ok {
-			return nil, fmt.Errorf("header %v not found in request.", headerName)
+			return nil, fmt.Errorf("header %s not found in request", headerName)
 		}
 		headerValues[i] = r.Header.Get(headerName)
 	}

--- a/httpsign/signer.go
+++ b/httpsign/signer.go
@@ -78,7 +78,7 @@ type Signer struct {
 func New(config *Config) (*Signer, error) {
 	// config is required!
 	if config == nil {
-		return nil, fmt.Errorf("config is required")
+		return nil, fmt.Errorf("config is required.") //nolint:stylecheck // TODO(v5): ST1005: error strings should not end with punctuation or newlines
 	}
 
 	// set defaults if not set
@@ -147,7 +147,7 @@ func New(config *Config) (*Signer, error) {
 // Signs a given HTTP request with signature, nonce, and timestamp.
 func (s *Signer) SignRequest(r *http.Request) error {
 	if s.secretKey == nil {
-		return fmt.Errorf("service not loaded with key")
+		return fmt.Errorf("service not loaded with key.") //nolint:stylecheck // TODO(v5): ST1005: error strings should not end with punctuation or newlines
 	}
 	return s.SignRequestWithKey(r, s.secretKey)
 }
@@ -192,7 +192,7 @@ func (s *Signer) SignRequestWithKey(r *http.Request, secretKey []byte) error {
 // VerifyRequest checks that an HTTP request was sent by an authorized sender.
 func (s *Signer) VerifyRequest(r *http.Request) error {
 	if s.secretKey == nil {
-		return fmt.Errorf("service not loaded with key")
+		return fmt.Errorf("service not loaded with key.") //nolint:stylecheck // TODO(v5): ST1005: error strings should not end with punctuation or newlines
 	}
 	return s.VerifyRequestWithKey(r, s.secretKey)
 }

--- a/httpsign/signer_test.go
+++ b/httpsign/signer_test.go
@@ -1,6 +1,7 @@
 package httpsign
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ var (
 )
 
 func TestSignRequest(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -61,7 +63,7 @@ func TestSignRequest(t *testing.T) {
 		}
 
 		body := strings.NewReader(tt.inRequestBody)
-		request, err := http.NewRequest(tt.inHttpVerb, tt.inRequestUri, body)
+		request, err := http.NewRequestWithContext(ctx, tt.inHttpVerb, tt.inRequestUri, body)
 		if err != nil {
 			t.Errorf("[%v] Got unexpected error from http.NewRequest: %v", i, err)
 		}
@@ -100,6 +102,7 @@ func TestSignRequest(t *testing.T) {
 }
 
 func TestAuthenticateRequest(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -133,7 +136,7 @@ func TestAuthenticateRequest(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Got unexpected error from http.NewRequest: %v", err)
 	}
@@ -155,6 +158,7 @@ func TestAuthenticateRequest(t *testing.T) {
 }
 
 func TestAuthenticateRequestWithHeaders(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -188,7 +192,7 @@ func TestAuthenticateRequestWithHeaders(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Got unexpected error from http.NewRequest: %v", err)
 	}
@@ -211,6 +215,7 @@ func TestAuthenticateRequestWithHeaders(t *testing.T) {
 }
 
 func TestAuthenticateRequestWithKey(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -244,7 +249,7 @@ func TestAuthenticateRequestWithKey(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Got unexpected error from http.NewRequest: %v", err)
 	}
@@ -266,6 +271,7 @@ func TestAuthenticateRequestWithKey(t *testing.T) {
 }
 
 func TestAuthenticateRequestWithVerbAndUri(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -299,7 +305,7 @@ func TestAuthenticateRequestWithVerbAndUri(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Got unexpected error from http.NewRequest: %v", err)
 	}
@@ -321,6 +327,7 @@ func TestAuthenticateRequestWithVerbAndUri(t *testing.T) {
 }
 
 func TestAuthenticateRequestForged(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -354,7 +361,7 @@ func TestAuthenticateRequestForged(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
@@ -375,6 +382,7 @@ func TestAuthenticateRequestForged(t *testing.T) {
 }
 
 func TestAuthenticateRequestMissingHeaders(t *testing.T) {
+	ctx := context.Background()
 	clock.Freeze(clock.Unix(1330837567, 0))
 	defer clock.Unfreeze()
 	randomPrv = &fakeRandom{}
@@ -408,7 +416,7 @@ func TestAuthenticateRequestMissingHeaders(t *testing.T) {
 
 	// setup request to test with
 	body := strings.NewReader(`{"hello": "world"}`)
-	request, err := http.NewRequest("POST", ts.URL, body)
+	request, err := http.NewRequestWithContext(ctx, "POST", ts.URL, body)
 	if err != nil {
 		t.Errorf("Got unexpected error from http.NewRequest: %v", err)
 	}

--- a/httpsign/signer_test.go
+++ b/httpsign/signer_test.go
@@ -26,9 +26,9 @@ func TestSignRequest(t *testing.T) {
 
 	var signtests = []struct {
 		inHeadersToSign     map[string]string
-		inSignVerbAndUri    bool
-		inHttpVerb          string
-		inRequestUri        string
+		inSignVerbAndURI    bool
+		inHTTPVerb          string
+		inRequestURI        string
 		inRequestBody       string
 		outNonce            string
 		outTimestamp        string
@@ -53,7 +53,7 @@ func TestSignRequest(t *testing.T) {
 			&Config{
 				KeyBytes:           testKey,
 				HeadersToSign:      headerNames,
-				SignVerbAndURI:     tt.inSignVerbAndUri,
+				SignVerbAndURI:     tt.inSignVerbAndURI,
 				NonceCacheCapacity: defaultCacheCapacity,
 				NonceCacheTimeout:  defaultCacheTimeout,
 			},
@@ -63,7 +63,7 @@ func TestSignRequest(t *testing.T) {
 		}
 
 		body := strings.NewReader(tt.inRequestBody)
-		request, err := http.NewRequestWithContext(ctx, tt.inHttpVerb, tt.inRequestUri, body)
+		request, err := http.NewRequestWithContext(ctx, tt.inHTTPVerb, tt.inRequestURI, body)
 		if err != nil {
 			t.Errorf("[%v] Got unexpected error from http.NewRequest: %v", i, err)
 		}

--- a/random/random.go
+++ b/random/random.go
@@ -15,7 +15,12 @@ const AlphaRunes = UpperAlphaRunes + LowerAlphaRunes
 func Runes(prefix string, length int, runes ...string) string {
 	chars := strings.Join(runes, "")
 	var bytes = make([]byte, length)
-	_, _ = rand.Read(bytes)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		// TODO(v5): Return this error instead?
+		panic(fmt.Errorf("while reading random bytes: %w", err))
+	}
+
 	for i, b := range bytes {
 		bytes[i] = chars[b%byte(len(chars))]
 	}
@@ -35,7 +40,12 @@ func String(prefix string, length int) string {
 // Given a list of strings, return one of the strings randomly
 func Item(items ...string) string {
 	var bytes = make([]byte, 1)
-	_, _ = rand.Read(bytes)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		// TODO(v5): Return this error instead?
+		panic(fmt.Errorf("while reading random bytes: %w", err))
+	}
+
 	return items[bytes[0]%byte(len(items))]
 }
 

--- a/random/random.go
+++ b/random/random.go
@@ -1,8 +1,8 @@
 package random
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"strings"
 )
 
@@ -15,7 +15,7 @@ const AlphaRunes = UpperAlphaRunes + LowerAlphaRunes
 func Runes(prefix string, length int, runes ...string) string {
 	chars := strings.Join(runes, "")
 	var bytes = make([]byte, length)
-	rand.Read(bytes)
+	_, _ = rand.Read(bytes)
 	for i, b := range bytes {
 		bytes[i] = chars[b%byte(len(chars))]
 	}
@@ -35,7 +35,7 @@ func String(prefix string, length int) string {
 // Given a list of strings, return one of the strings randomly
 func Item(items ...string) string {
 	var bytes = make([]byte, 1)
-	rand.Read(bytes)
+	_, _ = rand.Read(bytes)
 	return items[bytes[0]%byte(len(items))]
 }
 

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -41,10 +41,7 @@ func (e *Err) Error() string {
 
 func (e *Err) Is(target error) bool {
 	_, ok := target.(*Err)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }
 
 // Stop forces the retry to cancel with the provided error

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -162,12 +162,11 @@ func TestBackoffRace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			err := retry.Until(ctx, backOff, func(ctx context.Context, att int) error {
+			defer wg.Done()
+			_ = retry.Until(ctx, backOff, func(ctx context.Context, att int) error {
 				t.Logf("Attempts: %d", backOff.NumRetries())
 				return fmt.Errorf("failed attempt '%d'", att)
 			})
-			require.NoError(t, err)
-			wg.Done()
 		}()
 	}
 	wg.Wait()

--- a/syncutil/broadcast_test.go
+++ b/syncutil/broadcast_test.go
@@ -67,7 +67,7 @@ func TestBroadcaster(t *testing.T) {
 
 		var count int
 		for msg := range socket {
-			fmt.Printf(msg)
+			t.Log(msg)
 			count++
 			if count == 10 {
 				break

--- a/syncutil/fanout.go
+++ b/syncutil/fanout.go
@@ -46,15 +46,9 @@ func NewFanOut(size int) *FanOut {
 func (p *FanOut) start() {
 	p.wg.Add(1)
 	go func() {
-		for {
-			select {
-			case err, ok := <-p.errChan:
-				if !ok {
-					p.wg.Done()
-					return
-				}
-				p.errs = append(p.errs, err)
-			}
+		defer p.wg.Done()
+		for err := range p.errChan {
+			p.errs = append(p.errs, err)
 		}
 	}()
 }

--- a/syncutil/waitgroup_test.go
+++ b/syncutil/waitgroup_test.go
@@ -91,18 +91,16 @@ OUT:
 }
 
 func (s *WaitGroupTestSuite) TestLoop() {
-	pipe := make(chan int32, 0)
+	pipe := make(chan int32)
 	var wg syncutil.WaitGroup
 	var count int32
 
 	wg.Loop(func() bool {
-		select {
-		case inc, ok := <-pipe:
-			if !ok {
-				return false
-			}
-			atomic.AddInt32(&count, inc)
+		inc, ok := <-pipe
+		if !ok {
+			return false
 		}
+		atomic.AddInt32(&count, inc)
 		return true
 	})
 
@@ -120,7 +118,7 @@ func (s *WaitGroupTestSuite) TestLoop() {
 }
 
 func (s *WaitGroupTestSuite) TestUntil() {
-	pipe := make(chan int32, 0)
+	pipe := make(chan int32)
 	var wg syncutil.WaitGroup
 	var count int32
 

--- a/testutil/until_test.go
+++ b/testutil/until_test.go
@@ -1,4 +1,3 @@
-// #nosec
 package testutil_test
 
 import (

--- a/testutil/until_test.go
+++ b/testutil/until_test.go
@@ -1,3 +1,4 @@
+// #nosec
 package testutil_test
 
 import (

--- a/tracing/level.go
+++ b/tracing/level.go
@@ -96,7 +96,7 @@ func (t *LevelTracer) Start(ctx context.Context, spanName string, opts ...trace.
 }
 
 func logLevelName(level Level) string {
-	if level >= 0 && level <= 6 {
+	if level <= 6 {
 		return logLevelNames[level]
 	}
 	return ""

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -22,9 +22,6 @@ import (
 	"github.com/uptrace/opentelemetry-go-extra/otellogrus"
 )
 
-// Context Values key for embedding `Tracer` object.
-type tracerKey struct{}
-
 type initState struct {
 	opts  []sdktrace.TracerProviderOption
 	level Level

--- a/udp/proxy_test.go
+++ b/udp/proxy_test.go
@@ -33,7 +33,7 @@ func TestServerClient(t *testing.T) {
 	require.NoError(t, err)
 
 	b := make([]byte, 50)
-	n, _, err := conn.Recv(b, time.Second)
+	n, _, _ := conn.Recv(b, time.Second)
 
 	assert.Equal(t, "Hello, Thrawn", string(b[:n]))
 }
@@ -81,7 +81,7 @@ func TestProxy(t *testing.T) {
 	// Should not get a response from the upstream server
 	_, err = conn.Send([]byte("Not expecting a response"))
 	require.NoError(t, err)
-	n, _, err = conn.Recv(b, time.Second)
+	_, _, err = conn.Recv(b, time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "recvfrom: connection refused")
 

--- a/udp/proxy_test.go
+++ b/udp/proxy_test.go
@@ -33,7 +33,8 @@ func TestServerClient(t *testing.T) {
 	require.NoError(t, err)
 
 	b := make([]byte, 50)
-	n, _, _ := conn.Recv(b, time.Second)
+	n, _, err := conn.Recv(b, time.Second)
+	require.NoError(t, err)
 
 	assert.Equal(t, "Hello, Thrawn", string(b[:n]))
 }


### PR DESCRIPTION
https://mailgun.atlassian.net/browse/PIP-2108

* Enable linters: `goimports`, `gosec`, `gosimple`, `govet`, `ineffassign`, `staticcheck`, `noctx`, `stylecheck`, `typecheck`, `unused`.
* Fix unit tests.

Notable bugs fixed:

* `staticcheck` identified incorrect usage of `runtime.SetFinalizer()` in `discovery/memberlist.go` that prevents finalizer invocation and would cause a memory leak.
* `govet` identified an incomplete implementation of `ToMap()` in `errors/errors.go` that has been refactored to intended functionality.