### PR TITLE
PIP-2108: Fix TLS error connecting to etcd

### DIFF
--- a/etcdutil/config.go
+++ b/etcdutil/config.go
@@ -71,7 +71,7 @@ func NewConfig(cfg *etcd.Config) (*etcd.Config, error) {
 	}
 
 	defaultCfg := &tls.Config{
-		MinVersion: tls.VersionTLS13,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	// If the CA file was provided


### PR DESCRIPTION
Fixes error when using `etcdutil` to connect to etcd "transport: authentication handshake failed: remote error: tls: protocol version not supported".