### PR TITLE
PIP-2248: Fix timeout in `tracing` unit tests.

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/jaeger"
@@ -140,9 +139,6 @@ func CloseTracing(ctx context.Context) error {
 	if !ok {
 		return errors.New("OpenTelemetry global tracer provider has not been initialized")
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 
 	err := tp.Shutdown(ctx)
 	if err != nil {


### PR DESCRIPTION
https://mailgun.atlassian.net/browse/PIP-2248

Closes #154

Fix timeout error occurring in unit tests for `tracing` package.

Solution was to remove an unnecessary `context.WithTimeout()` in `CloseTracing()` because the underlying call to OTel's `Shutdown()` already has a 10s timeout applied.