### PR TITLE
add support for marshal/unmarshal gopkg.in/yaml marshaler

### DIFF
--- a/clock/rfc822.go
+++ b/clock/rfc822.go
@@ -97,6 +97,19 @@ func (t RFC822Time) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.Quote(t.Format(RFC1123))), nil
 }
 
+func (t RFC822Time) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+func (t *RFC822Time) UnmarshalText(s []byte) error {
+	parsed, err := ParseRFC822Time(string(s))
+	if err != nil {
+		return err
+	}
+	t.Time = parsed
+	return nil
+}
+
 func (t *RFC822Time) UnmarshalJSON(s []byte) error {
 	q, err := strconv.Unquote(string(s))
 	if err != nil {

--- a/clock/rfc822_test.go
+++ b/clock/rfc822_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 type testStruct struct {
-	Time RFC822Time `json:"ts"`
+	Time RFC822Time `json:"ts" yaml:"ts"`
 }
 
 func TestRFC822New(t *testing.T) {
@@ -40,6 +41,19 @@ func TestRFC822SecondPrecision(t *testing.T) {
 	rfc822Time2 := NewRFC822Time(stdTime2)
 	assert.True(t, rfc822Time1.Equal(rfc822Time2.Time),
 		"want=%s, got=%s", rfc822Time1.Time, rfc822Time2.Time)
+}
+
+func TestRFC822YAMLMarshaler(t *testing.T) {
+	rfcTime := NewRFC822Time(Date(1955, November, 12, 6, 38, 0, 0, UTC))
+	ts := testStruct{Time: rfcTime}
+	encoded, err := yaml.Marshal(ts)
+	assert.NoError(t, err)
+	assert.Equal(t, "ts: Sat, 12 Nov 1955 06:38:00 UTC\n", string(encoded))
+
+	var decoded testStruct
+	err = yaml.Unmarshal(encoded, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, rfcTime, decoded.Time)
 }
 
 // Marshaled representation is truncated down to second precision.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,13 +17,13 @@ services:
       - 22379:22379
 
   consul-agent:
-    image: consul:latest
+    image: hashicorp/consul:latest
     command: "agent -retry-join consul-server-bootstrap -client 0.0.0.0"
     volumes:
       - ${PWD}/consul/config:/consul/config
 
   consul-server-bootstrap:
-    image: consul:latest
+    image: hashicorp/consul:latest
     ports:
       - "8400:8400"
       - "8500:8500"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0
 	golang.org/x/net v0.8.0
 	google.golang.org/grpc v1.55.0
-	sigs.k8s.io/yaml v1.3.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -83,6 +83,4 @@ require (
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -780,5 +780,3 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
-sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/mongoutil/uri_test.go
+++ b/mongoutil/uri_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mailgun/holster/v4/mongoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMongoConfig_URIWithOptions(t *testing.T) {


### PR DESCRIPTION
### Purpose
The openapi yaml generator we use in scaffold is using `gopkg.in/yaml.v3`, which does not format `clock.RFC822` the same as the json marshaler.  It is formatting the string as `1955-11-12T06:38:00Z`, which will result in the wrong date format being displayed in response examples in the openapi yamls scaffold generates.  This updates `clock.RFC822` to support this yaml marshal/unmarshaler

### Implementation
- Discovered in my debugging that when calling `yaml.Marshal()` and `yaml.Unmarshal()` that it is using the `MarshalText()` and `UnmarshalText(0` methods.  This adds those methods to `clock.RFC822` so that it marshals the datetime in `clock.RFC1123` format. 
- `clock.RFC822` implements `UnmarshalText()` so that the datetime is parsed properly when unmarshaling. 
- Build was faling because docker-compose couldn't find `consul:latest`, Looks like it was deprecated in favor for [hashicorp/consul:latest](https://github.com/hashicorp/consul/issues/17973). 


https://mailgun.atlassian.net/browse/PIP-2562