### PR TITLE
BDF-1252: Add GetLevel

### DIFF
--- a/consul/log.go
+++ b/consul/log.go
@@ -87,6 +87,10 @@ func (a *HCLogAdapter) SetLevel(hclog.Level) {
 	// we don't currently.
 }
 
+func (a *HCLogAdapter) GetLevel() hclog.Level {
+	return hclog.Level(a.log.WithFields(logrus.Fields{}).Level)
+}
+
 func (a *HCLogAdapter) With(args ...interface{}) hclog.Logger {
 	e := a.CreateEntry(args)
 	return &HCLogAdapter{

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       -initial-cluster etcd0=http://0.0.0.0:2381
       -initial-cluster-state new
       -enable-v2=false
+    platform: linux/amd64
     ports:
       - 22379:22379
 


### PR DESCRIPTION
Add GetLevel to address `*HCLogAdapter does not implement hclog.Logger (missing method GetLevel)`