### PR TITLE
PIP 2712: Reuse open telemetry interceptors

### DIFF
--- a/grpcconn/grpcconn.go
+++ b/grpcconn/grpcconn.go
@@ -389,9 +389,9 @@ func (cm *ConnMgr[T]) newConnection(endpoint string) (*Conn[T], error) {
 	ctx, cancel := context.WithTimeout(cm.ctx, cm.cfg.RPCTimeout)
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+		grpc.WithTransportCredentials(insecureCredentials),
+		grpc.WithUnaryInterceptor(otelUnaryInterceptor),
+		grpc.WithStreamInterceptor(otelStreamInterceptor),
 	}
 	grpcConn, err := grpc.DialContext(ctx, endpoint, opts...)
 	cancel()
@@ -405,6 +405,12 @@ func (cm *ConnMgr[T]) newConnection(endpoint string) (*Conn[T], error) {
 		id:     id,
 	}, nil
 }
+
+var (
+	insecureCredentials   = insecure.NewCredentials()
+	otelUnaryInterceptor  = otelgrpc.UnaryClientInterceptor()
+	otelStreamInterceptor = otelgrpc.StreamClientInterceptor()
+)
 
 func (cm *ConnMgr[T]) getServerEndpoints(ctx context.Context) (*GetGRPCEndpointsRs, error) {
 	rq, err := http.NewRequestWithContext(ctx, "GET", cm.getEndpointsURL, http.NoBody)

--- a/mxresolv/mxresolv_test.go
+++ b/mxresolv/mxresolv_test.go
@@ -164,6 +164,10 @@ func TestLookup(t *testing.T) {
 		inDomainName:  "test-mx-ipv6.definbox.com",
 		outMXHosts:    []string{"::ffff:2296:b0e1"},
 		outImplicitMX: false,
+	}, {
+		inDomainName:  "arenhp.co.uk",
+		outMXHosts:    []string{"arenhp.co.uk"},
+		outImplicitMX: false,
 	}} {
 		t.Run(tc.inDomainName, func(t *testing.T) {
 			defer mxresolv.SetDeterministic()()


### PR DESCRIPTION
* Bug: Every time when a new gRPC connection is created a new pair of `opentelementry` interceptors is also created. Those interceptors are not released when the connection is closed. Over time the number of allocated interceptors grows causing a slow memory leak. The leak is particularly pronounced in `bunker` service that repeatedly creates disposable `bunker` clients to access data in other regions. 
* Also an optional WithLogger parameter was added to the `grpcconn.NewConnMgr`