### PR TITLE
slice.Remove

### DIFF
--- a/slice/remove.go
+++ b/slice/remove.go
@@ -1,0 +1,23 @@
+package slice
+
+// Remove removes the given index range from the given slice, preserving element order.
+// It is the safer version of slices.Delete() as it will
+// not panic on invalid slice ranges. Nil and empty slices are also safe.
+// Remove modifies the contents of the given slice and performs no allocations
+// or copies.
+func Remove[T comparable](slice []T, i, j int) []T {
+	// Nothing to do for emtpy slices or starting indecies outside range
+	if len(slice) == 0 || i > len(slice) {
+		return slice
+	}
+	// Prevent invalid slice indexing
+	if i < 0 || j > len(slice) {
+		return slice
+	}
+	// Removing the last element is a simple re-slice
+	if i == len(slice)-1 && j >= len(slice) {
+		return slice[:i]
+	}
+	// Note: this modifies the slice
+	return append(slice[:i], slice[j:]...)
+}

--- a/slice/remove_test.go
+++ b/slice/remove_test.go
@@ -1,0 +1,108 @@
+package slice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mailgun/holster/v4/slice"
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleRemove() {
+	s := []string{"1", "2", "3"}
+	i := []int{1, 2, 3}
+
+	fmt.Println(slice.Remove(s, 0, 2))
+	fmt.Println(slice.Remove(i, 1, 2))
+	// Output:
+	// [3]
+	// [1 3]
+}
+
+func TestRemove(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		i        int
+		j        int
+		inSlice  []int
+		outSlice []int
+	}{{
+		name:     "empty slice",
+		inSlice:  []int{},
+		outSlice: []int{},
+	}, {
+		name:     "nil check",
+		i:        1,
+		j:        3,
+		inSlice:  nil,
+		outSlice: nil,
+	}, {
+		name:     "start index out of range should not panic or modify the slice",
+		i:        -2,
+		j:        2,
+		inSlice:  []int{2},
+		outSlice: []int{2},
+	}, {
+		name:     "end index out of range should not panic or modify the slice",
+		i:        0,
+		j:        5,
+		inSlice:  []int{2},
+		outSlice: []int{2},
+	}, {
+		name:     "invalid start and end index should not panic or modify the slice",
+		i:        4,
+		j:        7,
+		inSlice:  []int{2},
+		outSlice: []int{2},
+	}, {
+		name:     "single value remove",
+		i:        0,
+		j:        1,
+		inSlice:  []int{1, 2, 3},
+		outSlice: []int{2, 3},
+	}, {
+		name:     "middle value removed",
+		i:        1,
+		j:        2,
+		inSlice:  []int{1, 2, 3},
+		outSlice: []int{1, 3},
+	}, {
+		name:     "last value removed",
+		i:        2,
+		j:        3,
+		inSlice:  []int{1, 2, 3},
+		outSlice: []int{1, 2},
+	}, {
+		name:     "multi-value remove",
+		i:        1,
+		j:        3,
+		inSlice:  []int{1, 2, 3},
+		outSlice: []int{1},
+	}, {
+		name:     "end of slice gut check for invalid ending index",
+		i:        2,
+		j:        5, // This index being out of bounds shouldn't matter
+		inSlice:  []int{1, 2, 3},
+		outSlice: []int{1, 2},
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			got := slice.Remove(test.inSlice, test.i, test.j)
+			for i := range test.outSlice {
+				assert.Equal(t, test.outSlice[i], got[i])
+			}
+		})
+	}
+}
+
+var out []string
+
+func BenchmarkRemove(b *testing.B) {
+	o := []string{}
+	in := []string{"localhost", "mg.example.com", "testlabs.io", "localhost", "m.example.com.br", "localhost", "localhost"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		o = slice.Remove(in, 2, 4)
+	}
+	out = o
+}


### PR DESCRIPTION
* Adds `slice.Remove` as a safer variant of the [slices.Delete()](https://pkg.go.dev/slices#Delete) function that avoids the panic case for invalid indecies

This function does fall within the warning about potential memory leaks if the slices modified are long-lived. See [slices.Delete()](https://pkg.go.dev/slices#Delete) docs for more info

## Implementation Notes

* Remove _does_ use the same in-place approach go/x/exp uses to achieve the in-place update.

## Benchmarking Checks

On an Intel Mac, to gut check the no-allocation claim:

```
goos: darwin
goarch: amd64
pkg: github.com/mailgun/holster/v4/slice
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkRemove-12       	242117806	         4.944 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	223956164	         4.946 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	244528929	         4.919 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	244414112	         4.878 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	244394427	         5.028 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	229395693	         4.942 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	243575570	         4.853 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	244754611	         5.171 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	234260016	         5.056 ns/op	       0 B/op	       0 allocs/op
BenchmarkRemove-12       	246132768	         4.855 ns/op	       0 B/op	       0 allocs/op
```