### PR TITLE
Add AddLink method to DummySpan

### DIFF
--- a/tracing/dummy_span.go
+++ b/tracing/dummy_span.go
@@ -69,5 +69,5 @@ func (s *DummySpan) TracerProvider() trace.TracerProvider {
 }
 
 func (s *DummySpan) AddLink(trace.Link) {
-       // no-op
+	// no-op
 }

--- a/tracing/dummy_span.go
+++ b/tracing/dummy_span.go
@@ -67,3 +67,7 @@ func (s *DummySpan) SetAttributes(kv ...attribute.KeyValue) {
 func (s *DummySpan) TracerProvider() trace.TracerProvider {
 	return s.parentSpan.TracerProvider()
 }
+
+func (s *DummySpan) AddLink(trace.Link) {
+       // no-op
+}


### PR DESCRIPTION
This is only in case you'd rather not merge #191 because of the minimum go version bump.

As it stands, projects with holster as indirect dependency cannot build if they also use otel v1.25.0. See also #189 
For example, a project using gubernator and otel 1.25.0 cannot build at the moment, because of this.

OTel added a new function to the Span interface, so this PR is the minimal change that can unblock things. I would prefer #191 to be merged, but either will work.