### PR TITLE
Downgrade toolchain version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.5.9

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   etcd:
-    image: quay.io/coreos/etcd:v3.2
+    image: quay.io/coreos/etcd:v3.5.9
     command: >
       /usr/local/bin/etcd
       -name etcd0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/mailgun/holster/v4
 
 go 1.21
 
+toolchain go1.21.12
+
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/ahmetb/go-linq v3.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/mailgun/holster/v4
 
 go 1.21
 
-toolchain go1.22.2
-
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/ahmetb/go-linq v3.0.0+incompatible


### PR DESCRIPTION
On `master` branch the `toolchain` directive adds a weird side effect:
```
# go version
go version go1.21.12 darwin/arm64

# cd holster
# go version
go: downloading go1.22.2 (darwin/arm64)
go version go1.22.2 darwin/arm64
```
and our 1.21 CI tests test it on 1.22:
```
Run actions/setup-go@v5
Setup go version spec 1.21.x
Found in cache @ /opt/hostedtoolcache/go/1.21.10/x64
Added go to the path
Successfully set up Go version 1.21.x
go: downloading go1.22.2 (linux/amd64)
...
Cache is not found
go version go1.22.2 linux/amd64
```
https://github.com/mailgun/holster/actions/runs/9158167548/job/25175965954

but all other services are using 1.21

---

It was added in https://github.com/mailgun/holster/pull/191/files?w=1

---

What is Go Toolchains - https://go.dev/doc/toolchain

---

Tested with https://github.com/mailgun/maverick-score/pull/84