### PR TITLE
Changing connection pool refresh log level to info

### DIFF
--- a/grpcconn/grpcconn.go
+++ b/grpcconn/grpcconn.go
@@ -373,7 +373,7 @@ func (cm *ConnMgr[T]) refreshConnPool() (clock.Duration, error) {
 	}
 	cm.connPoolMu.Unlock()
 	took := clock.Since(begin).Truncate(clock.Millisecond)
-	cm.log.Warnf("Connection pool refreshed: took=%s, zone=%s, poolSize=%d, newConnCount=%d, knownServerCount=%d, crossZoneCount=%d, ttl=%s",
+	cm.log.Infof("Connection pool refreshed: took=%s, zone=%s, poolSize=%d, newConnCount=%d, knownServerCount=%d, crossZoneCount=%d, ttl=%s",
 		took, cm.cfg.Zone, connPoolSize, newConnCount, len(getGRPCEndpointRs.Servers), crossZoneCount, ttl)
 	if connPoolSize < 1 {
 		return 0, errConnPoolEmpty


### PR DESCRIPTION
Maxim said it was warning for testing/rollout and can be downgraded to info